### PR TITLE
[WIP] Update history dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/NewSpring/newspring-core",
   "devDependencies": {},
   "dependencies": {
-    "history": "^1.13.1",
+    "history": "^1.17.0",
     "moment": "^2.10.6",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",


### PR DESCRIPTION
This fixes the `history` package dependency problem. 

`apollos` wanted ^1.13.1
`react-router` wanted ^1.17.0 as of it's update to 1.0.3 today
`redux-router` wanted ^1.12.0

I'm not sure if this will affect functionality yet.