### PR TITLE
ensure zip validation works for longer zips

### DIFF
--- a/give/blocks/Give/fieldsets/Billing.jsx
+++ b/give/blocks/Give/fieldsets/Billing.jsx
@@ -66,7 +66,7 @@ export default class Billing extends Component {
   }
 
   zip = (value) => {
-    let isValid = value.length === 5 ? true : false
+    let isValid = value.length >= 5 ? true : false
 
     if (!isValid ) {
       this.props.clear("zip")


### PR DESCRIPTION
Fixes #285 

@jbaxleyiii @jonhorton I changed this validation to >= 5, instead of trimming input to 5, because browser prefill will do whatever it feels like anyways. Keyboard input will still be limited to 5