### PR TITLE
make spinner work on all backgrounds

### DIFF
--- a/core/components/loading/spinner.css
+++ b/core/components/loading/spinner.css
@@ -14,7 +14,7 @@
 
     border-radius: 50%;
     display: inline-block;
-    border-color: #6BAC43 #FFF #6BAC43 #6BAC43;
+    border-color: #6BAC43 transparent #6BAC43 #6BAC43;
 
     width: 60px;
     height: 60px;


### PR DESCRIPTION
this should allow the spinner to be placed on any background

fixes this problem:

<img width="121" alt="screenshot 2016-03-06 19 51 42" src="https://cloud.githubusercontent.com/assets/816517/13558542/e78b95d4-e3d4-11e5-8e78-b0dffba3cd0d.png">
