### PR TITLE
Validate schedules

### DIFF
--- a/give/blocks/Give/fieldsets/Payment.jsx
+++ b/give/blocks/Give/fieldsets/Payment.jsx
@@ -268,7 +268,7 @@ export default class Payment extends Component {
               id="ccv"
               name="billing-cvv"
               label="CCV"
-              type="number"
+              type="tel"
               errorText="Please enter a valid ccv number"
               defaultValue={payment.ccv}
               onChange={this.saveData}

--- a/give/methods/give/server/charge.js
+++ b/give/methods/give/server/charge.js
@@ -16,6 +16,17 @@ function charge(token, accountName) {
     throw new Meteor.Error(e.message)
   }
 
+  // this was a validation action, we can save the card but that is all
+  // we should do. We shoud only do this if there is an account name present
+  // see https://github.com/NewSpring/Apollos/issues/439 for more details
+  if (response["action-type"] === "validate") {
+    const returnReponse = _.pick(response,
+      "avs-result", "order-id", "cvv-result", "result-code"
+    )
+    return returnReponse
+  }
+
+
   let user = null
   if (this.userId) {
     user = Meteor.users.findOne({ _id: this.userId })
@@ -116,6 +127,7 @@ function charge(token, accountName) {
     if (!Array.isArray(response.product)) {
       response.product = [ response.product ]
     }
+
     for (let product of response.product) {
       let endpoint = parseEndpoint(`
         FinancialAccounts?

--- a/give/methods/give/server/createSchedule.js
+++ b/give/methods/give/server/createSchedule.js
@@ -165,7 +165,6 @@ const createSchedule = (response, accountName, id, user) => {
     }
 
 
-
     ScheduledTransactionReciepts.insert(formatedFinancialScheduledTransaction, () => {
 
     })

--- a/give/methods/give/server/nmi/cancel-card.js
+++ b/give/methods/give/server/nmi/cancel-card.js
@@ -18,7 +18,6 @@ const cancelBilling = (customer, callback) => {
 
   const builder = new Builder()
   const xml = builder.buildObject(cancelBillingObj)
-  console.log(xml)
   return fetch("https://secure.networkmerchants.com/api/v2/three-step", {
     method: "POST",
     body: `${xml}`,
@@ -30,7 +29,6 @@ const cancelBilling = (customer, callback) => {
     return response.text()
   })
   .then((data) => {
-    console.log(data)
     try {
       data = parseXML(data)
     } catch (e) {

--- a/give/methods/give/server/nmi/charge.js
+++ b/give/methods/give/server/nmi/charge.js
@@ -55,13 +55,10 @@ const step1 = (token, callback) => {
       return
     }
 
-
     // AVS mismatch can be sucessful transactions but some merchants
     // will keep holds on peoples accounts even if the transacton failed.
     // Here we send a void for  any transactions with an AVS
     // mismatch IF there was a failure
-    // console.log(data)
-
     if (data["result-code"] === "100") {
       callback(null, data)
       return
@@ -81,6 +78,7 @@ const step1 = (token, callback) => {
       err = data["result-text"]
     }
 
+    console.error(data)
     callback(err)
 
   })

--- a/give/methods/give/server/nmi/order.js
+++ b/give/methods/give/server/nmi/order.js
@@ -33,7 +33,6 @@ const step2 = (purchaseData, method, callback) => {
 
   const builder = new Builder()
   const xml = builder.buildObject(sale)
-
   function timeout(ms, promise) {
     return new Promise(function(resolve, reject) {
       setTimeout(function() {

--- a/give/methods/give/server/order.js
+++ b/give/methods/give/server/order.js
@@ -19,9 +19,12 @@ function order(orderData, instant, id){
     method = "sale"
   }
 
-  // subscription creation
   if (orderData["start-date"]) {
     method = "add-subscription"
+  }
+
+  if (orderData.amount === 0) {
+    method = "validate"
   }
 
   if (user && user.services.rock && method != "add-subscription") {
@@ -51,12 +54,15 @@ function order(orderData, instant, id){
 
     orderData["ip-address"] = ip
 
+    // strongly force CVV on acctions that aren't a saved account
+    if (!orderData["customer-vault-id"]) {
+      orderData["cvv-reject"] = "P|N|S|U"
+    }
   }
 
   try {
 
     let response = Meteor.wrapAsync(gatewayOrder)(orderData, method)
-
     if (instant) {
       response = createSchedule(response, null, id, user)
     }

--- a/give/store/give/saga/formatPersonDetails.js
+++ b/give/store/give/saga/formatPersonDetails.js
@@ -28,7 +28,7 @@ const formatPersonDetails = (give, { campuses }) => {
 
   joinedData["merchant-defined-field-2"] = campusId
 
-  if (Object.keys(schedules).length) {
+  if (schedules && Object.keys(schedules).length) {
     // // @TODO allow custom start dates
     // joinedData["start-date"] = Moment().format("YYYYMMDD")
     // @TODO allow number of payments
@@ -74,7 +74,7 @@ const formatPersonDetails = (give, { campuses }) => {
     }
 
 
-  } else {
+  } else if (transactions && Object.keys(transactions).length) {
 
     joinedData.product = []
     for (let transaction in transactions) {


### PR DESCRIPTION
This PR requires validation of schedule prior to setting it up. It is a hacky work around of NMI's system for creating a schedule and validating a card.

Currently NMI does not let you validate + create a schedule even though it seems like it should be possible thanks to [this](https://secure.networkmerchants.com/gw/merchants/resources/integration/integration_portal.php#transactions_step_1)

However, using `<validate><add-subscription></add-subscription></validate>` returns an error. Instead, we make a hidden 3 step transaction happen that is *just* a validate during the final checkout process of a schedule when a user doesn't have an account.

Technically this will make it possible to save a payment during a schedule too, but more work will need to be done on the Rock side since a saved payment requires a transaction and we don't want to create a `$0` transaction to store this.
