### PR TITLE
Mind the gap

### DIFF
--- a/core/util/rock/startup.js
+++ b/core/util/rock/startup.js
@@ -55,7 +55,7 @@ export default function startup(api) {
     api._.give || (api._.give = {})
 
     // Gateways
-    let NMI = api.get.sync("FinancialGateways?$filter=EntityType/Name eq 'Rock.Financial.NMIGateway'&$expand=EntityType")
+    let NMI = api.get.sync("FinancialGateways?$filter=substringof('NMI', EntityType/Name) eq true&$expand=EntityType")
 
     if (!NMI.statusText && NMI.length) {
       // Meteor.settings.nmi = NMI

--- a/give/methods/paymentAccounts/server/index.js
+++ b/give/methods/paymentAccounts/server/index.js
@@ -5,6 +5,7 @@ import { cancelBilling as gatewayCancelBilling } from "../../give/server/nmi"
 const remove = (id) => {
 
   let existing = api.get.sync(`FinancialPersonSavedAccounts/${id}`)
+  let result = api.delete.sync(`FinancialPersonSavedAccounts/${id}`)
 
   // only remove if this is an NMI transaction and we have a gateway code
   if (existing.ReferenceNumber && existing.FinancialGatewayId === api._.give.gateway.id) {
@@ -14,8 +15,6 @@ const remove = (id) => {
       throw new Meteor.Error(e.message ? e.message : e)
     }
   }
-
-  let result = api.delete.sync(`FinancialPersonSavedAccounts/${id}`)
 
   if (result.status) {
     throw new Meteor.Error(result)


### PR DESCRIPTION
adjust query to bridge the gap between entity model names and ensure saved payments can be removed

The updates to NMI in rock changed the entity name of the gateway (https://github.com/NewSpring/Rock/commit/599b7ed16c438dfbbb04a318ff53d593b8cbf6fd) so we need to adjust the api fetch query to work with both names.

This PR also ensures removing a saved card actually does that