### PR TITLE
App audio player navigation state

### DIFF
--- a/apollos/core/blocks/modal/index.jsx
+++ b/apollos/core/blocks/modal/index.jsx
@@ -30,8 +30,9 @@ export default class SideModalContainer extends Component {
 
   }
 
-  componentDidMount(){
-    if (!this.props.modal.props.keepNav && this.props.modal.visible) {
+  componentDidMount() {
+    if(!this.props.modal.props.keepNav && this.props.modal.visible)
+    {
       this.props.dispatch(navActions.setLevel("MODAL"))
     }
 
@@ -45,17 +46,18 @@ export default class SideModalContainer extends Component {
     if (Meteor.isClient) {
       document.removeEventListener("keyup", this.bindEsc, false)
     }
+    this.props.dispatch(navActions.resetColor())
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.modal.visible && nextProps.navigation.level != "MODAL" && nextProps.modal.props.keepNav != true) {
+    if (nextProps.modal.visible && nextProps.navigation.level != "MODAL" && nextProps.navigation.level != "DOWN" && nextProps.modal.props.keepNav != true) {
       this.props.dispatch(navActions.setLevel("MODAL"))
       this.setState({ previous: this.props.navigation.level })
     }
 
-    if (!nextProps.modal.visible && nextProps.navigation.level === "MODAL" && !this.props.modal.props.keepNav) {
+    if (!nextProps.modal.visible && nextProps.navigation.level === "MODAL" && nextProps.navigation.level === "DOWN" && !this.props.modal.props.keepNav) {
       let previous = this.state.previous
-      if (previous === "MODAL" || !previous) {
+      if (previous === "MODAL" || previous === "DOWN" || !previous) {
         previous = "TOP"
       }
       this.props.dispatch(navActions.setLevel(previous))
@@ -80,8 +82,6 @@ export default class SideModalContainer extends Component {
         root.className += " modal--opened"
       }
     }
-
-
   }
 
   close = (e) => {

--- a/apollos/core/blocks/nav/Layout.jsx
+++ b/apollos/core/blocks/nav/Layout.jsx
@@ -43,7 +43,7 @@ export default class NavLayout extends React.Component {
 
     const { handleAction, back, reset } = this.props
     return (
-      <section className={ this.props.theme || this.layoutClasses() } style={{backgroundColor: "#202020"}}>
+      <section className={ this.props.theme || this.layoutClasses() } style={{backgroundColor: this.props.color }}>
         {this.props.links.map((item, i) => {
           return (
             <NavLink

--- a/apollos/core/blocks/nav/index.jsx
+++ b/apollos/core/blocks/nav/index.jsx
@@ -35,6 +35,7 @@ export default class NavContainer extends Component {
         links={ state.links }
         handleAction={this.handleAction}
         back={this.getBackLink}
+        color={ state.color }
         reset={this.reset}
         modal={this.props.modal}
         liked={this.props.liked}

--- a/apollos/core/store/nav/index.js
+++ b/apollos/core/store/nav/index.js
@@ -35,9 +35,8 @@ addReducer({
 export default {
   reducer,
 
-  setLevel: (level) => ({ type: "NAV.SET_LEVEL", level}),
+  setLevel: (level) => ({ type: "NAV.SET_LEVEL", level }),
   reset: () => ({ type: "NAV.SET_LEVEL", level: "TOP" }),
-  // resetColor: () => ({type: "NAV.SET_COLOR", color: "#202020" }),
 
   setColor: (color) => ({ type: "NAV.SET_COLOR", color}),
 

--- a/apollos/core/store/nav/index.js
+++ b/apollos/core/store/nav/index.js
@@ -35,8 +35,11 @@ addReducer({
 export default {
   reducer,
 
-  setLevel: (level) => ({ type: "NAV.SET_LEVEL", level }),
+  setLevel: (level) => ({ type: "NAV.SET_LEVEL", level}),
   reset: () => ({ type: "NAV.SET_LEVEL", level: "TOP" }),
+  // resetColor: () => ({type: "NAV.SET_COLOR", color: "#202020" }),
+
+  setColor: (color) => ({ type: "NAV.SET_COLOR", color}),
 
   setLinks: (links) => ({ type: "NAV.SET_LINKS", links }),
   setAction: (level, props) => ({ type: "NAV.SET_ACTION", level, props }),

--- a/apollos/core/store/nav/reducer.js
+++ b/apollos/core/store/nav/reducer.js
@@ -81,6 +81,9 @@ let links = {
   ],
   MODAL: [
     { id: 1, action: modalActions.hide, icon:"icon-close" }
+  ],
+  DOWN: [
+    { id: 1, action: modalActions.hide, icon:"icon-arrow-down"}
   ]
 }
 
@@ -89,13 +92,14 @@ if (!Meteor.isCordova) {
   links = {
     TOP: links.TOP,
     CONTENT: links.TOP,
-    BASIC_CONTENT :links.TOP,
-    MODAL: links.MODAL
+    BASIC_CONTENT: links.TOP,
+    MODAL: links.MODAL,
+    DOWN: links.DOWN
   }
 }
 
 
-const initial = { level: "TOP", visible: true, links: links.TOP}
+const initial = { level: "TOP", visible: true, links: links.TOP, color: "#202020"}
 
 export default function nav(state = initial, action) {
 
@@ -103,11 +107,20 @@ export default function nav(state = initial, action) {
     case "NAV.SET_LEVEL":
       return { ...state, ...{
         level: action.level,
-        links: links[action.level]
+        links: links[action.level],
+        color: action.color || initial.color
       } }
     case "NAV.SET_LINKS":
       return { ...state, ...{
         links: [ ...state.links, ...action.links ]
+      } }
+    case "NAV.SET_COLOR":
+      return { ...state, ...{
+        color: action.color
+      } }
+    case "NAV.RESET_COLOR":
+      return { ...state, ...{
+        color: "#202020"
       } }
     case "NAV.SET_ACTION":
 

--- a/sites/app/modules/app/client/components/players/audio/index.jsx
+++ b/sites/app/modules/app/client/components/players/audio/index.jsx
@@ -6,7 +6,7 @@ import MiniPlayer from "./audio.MiniPlayer"
 import AudioPlayerUtility from "./audio.PlayerUtility"
 
 import { audio as audioActions } from "app/client/actions"
-import { modal } from "apollos/core/store"
+import { modal, nav as navActions } from "apollos/core/store"
 
 const mapStateToProps = (state) => {
   return {
@@ -31,11 +31,14 @@ export default class AudioPlayer extends Component {
     const modalClosing = modalVis && !modalNextVis;
 
     if( expanding ) {
-      this.props.dispatch(modal.render(FullPlayer));
+      this.props.dispatch(modal.render(FullPlayer, { audioPlayer: true }));
+      this.props.dispatch(navActions.setLevel("DOWN"));
+      this.props.dispatch(navActions.setColor("transparent"));
     }
 
     if( expanded && modalClosing ) {
       this.props.dispatch(audioActions.setVisibility("dock"));
+      this.props.dispatch(navActions.reset());
     }
 
   };


### PR DESCRIPTION
### Apollos 
- ability to set color for the nav 
- new state of down which sets `icon-down-arrow`

### App
- sets the color of the nav for the audio player to transparent
- sets the level of the audio modal to down 
- resets the color of the nav and the nav state when the player is dismissed