### PR TITLE
increase nav tap target

### DIFF
--- a/apollos/core/blocks/nav/Layout.jsx
+++ b/apollos/core/blocks/nav/Layout.jsx
@@ -14,6 +14,7 @@ export default class NavLayout extends React.Component {
       "soft-half",
       "locked-left",
       "locked-bottom",
+      "hard-ends@handheld",
       "hard-sides@lap-and-up",
       "soft-half-top@lap-and-up"
     ];

--- a/apollos/core/blocks/nav/Link.jsx
+++ b/apollos/core/blocks/nav/Link.jsx
@@ -71,9 +71,9 @@ export default class NavLink extends Component {
       <button
         className={this.linkClasses()}
         onClick={this.handleAction}
-        style={{minHeight: "40px"}}
+        style={{minHeight: "60px"}}
       >
-        <div className={`floating ${Styles["locked"]}`} >
+        <div className={`floating ${Styles["locked"]} soft-half-top@handheld`} >
           <div className="floating__item">
             <i className={iconClasses} style={itemStyle}></i>
             {() => {


### PR DESCRIPTION
@jonhorton Fixes #614 

<img width="550" alt="screenshot 2016-06-15 16 47 21" src="https://cloud.githubusercontent.com/assets/816517/16096904/115407a0-3319-11e6-848c-c7521fbe43b3.png">

all of the green and blue are tappable