### PR TITLE
set the status bar text back to white after fullscreen video

### DIFF
--- a/sites/app/modules/app/client/components/players/video/index.jsx
+++ b/sites/app/modules/app/client/components/players/video/index.jsx
@@ -77,6 +77,17 @@ export default class VideoPlayer extends Component {
         this.messages.subscribe(OO.EVENTS.PLAY_FAILED, "Video", (eventName) => {
           this.destroy();
         });
+
+        this.messages.subscribe(OO.EVENTS.FULLSCREEN_CHANGED, "Video", (eventName) => {
+          // ios sets the status bar text color to black
+          // when it goes full screen
+          if (!player.isFullscreen()) {
+            // wait a bit because it doesn't work right away
+            setTimeout(() => {
+              StatusBar.styleLightContent();
+            }, 500);
+          }
+        });
       }
     };
 


### PR DESCRIPTION
Fixes #653 

![o9egmijyol](https://cloud.githubusercontent.com/assets/816517/16102029/95d3ac0e-3339-11e6-8e47-08283335a03c.gif)
