### PR TITLE
remove animation on image loader

### DIFF
--- a/apollos/core/components/loading/FeedItemSkeleton.css
+++ b/apollos/core/components/loading/FeedItemSkeleton.css
@@ -6,6 +6,8 @@
 .fake-text-small {
   /* force hardware acceleration */
   -webkit-transform: translate3d(0, 0, 0);
+  -webkit-backface-visibility: hidden;
+  -webkit-perspective: 1000;
 
   background: linear-gradient(270deg, #dddddd, #bcbcbc, #dddddd);
   -webkit-animation: ColorAnimation 5s cubic-bezier(0.66, 0.21, 0.49, 0.88) infinite;
@@ -51,6 +53,8 @@
 :global(.imageloader.loaded > :first-child) {
   /* force hardware acceleration */
   -webkit-transform: translate3d(0, 0, 0);
+  -webkit-backface-visibility: hidden;
+  -webkit-perspective: 1000;
 
   opacity: 1;
   transition: opacity .5s ease-in-out;

--- a/apollos/core/components/loading/FeedItemSkeleton.css
+++ b/apollos/core/components/loading/FeedItemSkeleton.css
@@ -4,6 +4,9 @@
 
 .fake-text,
 .fake-text-small {
+  /* force hardware acceleration */
+  -webkit-transform: translate3d(0, 0, 0);
+
   background: linear-gradient(270deg, #dddddd, #bcbcbc, #dddddd);
   -webkit-animation: ColorAnimation 5s cubic-bezier(0.66, 0.21, 0.49, 0.88) infinite;
   animation: ColorAnimation 5s cubic-bezier(0.66, 0.21, 0.49, 0.88) infinite;
@@ -46,6 +49,9 @@
 }
 
 :global(.imageloader.loaded > :first-child) {
+  /* force hardware acceleration */
+  -webkit-transform: translate3d(0, 0, 0);
+
   opacity: 1;
   transition: opacity .5s ease-in-out;
  -moz-transition: opacity .5s ease-in-out;

--- a/apollos/core/components/loading/FeedItemSkeleton.css
+++ b/apollos/core/components/loading/FeedItemSkeleton.css
@@ -1,4 +1,7 @@
-.load-item,
+.load-item {
+  background: #dddddd;
+}
+
 .fake-text,
 .fake-text-small {
   background: linear-gradient(270deg, #dddddd, #bcbcbc, #dddddd);

--- a/apollos/core/components/loading/ImageLoader.jsx
+++ b/apollos/core/components/loading/ImageLoader.jsx
@@ -86,7 +86,12 @@ export default class ImageLoader extends Component {
 
     const isElementInView = (e) => {
       let coords = e.getBoundingClientRect()
-      return (Math.abs(coords.left) >= 0 && Math.abs(coords.top)) <= (window.innerHeight || document.documentElement.clientHeight)
+      return (
+        // if item is left of the screen's left side
+        Math.abs(coords.left) >= 0 &&
+        // if item is within two screens
+        Math.abs(coords.top) <= (window.innerHeight || document.documentElement.clientHeight) * 2
+      );
     }
 
     const seeIfInView = () => {

--- a/sites/app/stylesheets/one/two/three/custom/_hacks.scss
+++ b/sites/app/stylesheets/one/two/three/custom/_hacks.scss
@@ -4,7 +4,6 @@ html, body, #react-app {
   background: #303030;
 }
 
-
 /* hide web view scroll bars */
 ::-webkit-scrollbar,
 ::-webkit-scrollbar-track,

--- a/sites/app/stylesheets/one/two/three/custom/_refresh.scss
+++ b/sites/app/stylesheets/one/two/three/custom/_refresh.scss
@@ -57,6 +57,11 @@
 }
 
 .ptr-loading .ptr-element .loading {
+  /* force hardware acceleration on render */
+  -webkit-transform: translate3d(0, 0, 0);
+  -webkit-backface-visibility: hidden;
+  -webkit-perspective: 1000;
+
   display: block;
   -webkit-animation-duration: .5s;
   -ms-animation-duration: .5s;

--- a/sites/app/stylesheets/one/two/three/custom/_refresh.scss
+++ b/sites/app/stylesheets/one/two/three/custom/_refresh.scss
@@ -21,6 +21,11 @@
 }
 
 .refresh-view {
+  /* force hardware acceleration on render */
+  -webkit-transform: translate3d(0, 0, 0);
+  -webkit-backface-visibility: hidden;
+  -webkit-perspective: 1000;
+
   z-index: 1;
   position: relative;
 }

--- a/sites/app/stylesheets/one/two/three/master.scss
+++ b/sites/app/stylesheets/one/two/three/master.scss
@@ -22,6 +22,11 @@
 @import "./custom/scripture";
 
 .card {
+  /* force hardware acceleration on render */
+  -webkit-transform: translate3d(0, 0, 0);
+  -webkit-backface-visibility: hidden;
+  -webkit-perspective: 1000;
+
   background-color: #fff;
   border-width: 1px;
   border-color: rgba(0, 0, 0, .1);


### PR DESCRIPTION
Fixes #668 
Fixes #617 

This should improve render performance across the board. Now we have this for the skeleton and the cards while content/images are loading, respectively:

![screenshot 2016-06-16 09 23 13](https://cloud.githubusercontent.com/assets/816517/16118481/3e914322-33a5-11e6-9441-65fe3242763e.png)

![screenshot 2016-06-16 09 31 17](https://cloud.githubusercontent.com/assets/816517/16118486/4014edde-33a5-11e6-8f99-664413e88c43.png)
