### PR TITLE
lock redbox-react version

### DIFF
--- a/sites/app/package.json
+++ b/sites/app/package.json
@@ -93,7 +93,7 @@
     "null-loader": "^0.1.1",
     "raw-loader": "^0.5.1",
     "react-transform-catch-errors": "^1.0.0",
-    "redbox-react": "^1.2.5",
+    "redbox-react": "1.2.6",
     "redux-logger": "^2.6.1",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",


### PR DESCRIPTION
redbox-react 1.2.7 dropped react 0.14 support
redbox-react 1.2.8 doesn't work with our app for some reason

kept getting this:

```
imports[1] for react-transform-catch-errors does not look like a React component.
```

coming from FeedItemSkeleton.jsx importing css