### PR TITLE
Move settings icon

### DIFF
--- a/apollos/core/components/header/index.jsx
+++ b/apollos/core/components/header/index.jsx
@@ -1,5 +1,6 @@
 
 import { Component, PropTypes } from "react"
+import { Link } from "react-router"
 import { connect } from "react-redux"
 
 @connect((state) => ({
@@ -9,9 +10,20 @@ import { connect } from "react-redux"
   subText: state.header.content.subTitle,
   visible: state.header.visible,
   isSearch: state.header.content.isSearch,
+  showSettings: state.header.content.showSettings,
   searchSubmit: state.header.content.searchSubmit
 }))
 export default class Header extends Component {
+
+  showSettings = () => {
+    if (this.props.showSettings) {
+      return (
+      <Link to="/profile/settings" className="text-light-primary plain soft-half-top soft-half-right overlay__item locked-top locked-right" style={{marginTop: "-3px"}}>
+        <i className="icon-settings h4"></i>
+      </Link>
+      )
+    }
+  }
 
   render () {
     const lightColor = "text-light-primary";
@@ -77,6 +89,7 @@ export default class Header extends Component {
                 whiteSpace: "nowrap",
               }}>
                 {this.props.text}
+                {this.showSettings()}
               </h6>
             )
           })()}

--- a/apollos/core/store/header/reducer.js
+++ b/apollos/core/store/header/reducer.js
@@ -15,6 +15,7 @@ const initial = {
     color: brand,
     light: true,
     isSearch: false,
+    showSettings: false,
     searchSubmit: false
   },
 };

--- a/apollos/profile/pages/home/Layout.jsx
+++ b/apollos/profile/pages/home/Layout.jsx
@@ -6,11 +6,6 @@ import Meta from "react-helmet"
 import Split, { Left, Right } from "../../../core/blocks/split"
 import { Toggle } from "../../../core/components/controls"
 
-const SettingsLink = () => (
-  <Link to="/profile/settings" className="text-light-primary plain soft overlay__item locked-top locked-right">
-    <i className="icon-settings h4"></i>
-  </Link>
-)
 
 const Layout = ({ photo, person, onToggle, content, onUpload }, context) => (
   <div>
@@ -27,7 +22,6 @@ const Layout = ({ photo, person, onToggle, content, onUpload }, context) => (
         ratioClasses={["floating__item", "overlay__item", "one-whole", "text-center"]}
         background={photo}
         blur={true}
-        outsideRatio={SettingsLink}
       >
         <div className="soft one-whole">
           <label htmlFor="file"

--- a/apollos/profile/pages/home/index.jsx
+++ b/apollos/profile/pages/home/index.jsx
@@ -79,6 +79,7 @@ export default class Home extends Component {
   componentDidMount(){
     const item = {
       title: "Profile",
+      showSettings: true,
     };
 
     this.props.dispatch(headerActions.set(item));


### PR DESCRIPTION
Move the settings icon to the header. 

Now whenever the settings icon is needed, you should just have to add `showSettings: true` to the store and the icon with magically appear.

![](https://drwdes-dropshare.s3.amazonaws.com/MfteQvul4r/Screen-Shot-2016-06-21-15-21-32.png)

Closes #688 