### PR TITLE
use graphql-tag package

### DIFF
--- a/apollos/package.json
+++ b/apollos/package.json
@@ -69,6 +69,7 @@
     "compression": "^1.6.2",
     "cookie-parser": "^1.4.3",
     "google-map-react": "^0.14.8",
+    "graphql-tag": "^0.1.7",
     "history": "^3.0.0",
     "liquid-node": "git+https://github.com/NewSpring/liquid-node.git",
     "lodash.assign": "^4.0.9",

--- a/apollos/src/core/blocks/discover/feed/index.jsx
+++ b/apollos/src/core/blocks/discover/feed/index.jsx
@@ -1,6 +1,6 @@
 import { Component, PropTypes} from "react"
 import { connect } from "react-apollo";
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import { Likes } from "../../../collections"
 

--- a/apollos/src/core/blocks/discover/index.jsx
+++ b/apollos/src/core/blocks/discover/index.jsx
@@ -1,7 +1,7 @@
 import { Component, PropTypes } from "react"
 import { connect } from "react-apollo"
 import ReactMixin from "react-mixin"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import { Headerable } from "../../../core/mixins/";
 

--- a/apollos/src/core/pages/util/index.jsx
+++ b/apollos/src/core/pages/util/index.jsx
@@ -1,5 +1,5 @@
 import { Component, PropTypes} from "react"
-import gql from "apollo-client";
+import gql from "graphql-tag";
 
 import { GraphQL } from "../../graphql";
 import Split, { Left, Right } from "../../blocks/split"

--- a/apollos/src/core/store/accounts/saga.js
+++ b/apollos/src/core/store/accounts/saga.js
@@ -1,6 +1,6 @@
 import "regenerator-runtime/runtime"
 import { take, put, cps, call } from "redux-saga/effects"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import { GraphQL } from "../../graphql"
 import accounts from "../../methods/accounts/client"

--- a/apollos/src/core/store/sections/saga.js
+++ b/apollos/src/core/store/sections/saga.js
@@ -1,7 +1,7 @@
 import "regenerator-runtime/runtime"
 
 import { take, put } from "redux-saga/effects"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 import { addSaga } from "../utilities"
 import { GraphQL } from "../../graphql";
 

--- a/apollos/src/give/blocks/ActionButtons/index.jsx
+++ b/apollos/src/give/blocks/ActionButtons/index.jsx
@@ -1,6 +1,6 @@
 import { Component, PropTypes} from "react"
 import { connect } from "react-apollo"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import OnBoard from "../../../core/blocks/accounts"
 

--- a/apollos/src/give/blocks/Give/index.jsx
+++ b/apollos/src/give/blocks/Give/index.jsx
@@ -1,7 +1,7 @@
 import { Component, PropTypes} from "react"
 import ReactDOM from "react-dom"
 import { connect } from "react-apollo";
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 import Moment from "moment"
 
 import { Controls, Forms } from "../../../core/components";

--- a/apollos/src/give/pages/campaign/index.jsx
+++ b/apollos/src/give/pages/campaign/index.jsx
@@ -1,6 +1,6 @@
 import { Component, PropTypes} from "react"
 import { connect } from "react-apollo";
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import { Loading } from "../../../core/components"
 import { nav as navActions } from "../../../core/store"

--- a/apollos/src/give/pages/history/Details/index.jsx
+++ b/apollos/src/give/pages/history/Details/index.jsx
@@ -1,6 +1,6 @@
 import { Component, PropTypes} from "react"
 import { connect } from "react-apollo"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import { nav as navActions } from "../../../../core/store"
 import { transactions as transactionActions } from "../../../store"

--- a/apollos/src/give/pages/history/index.jsx
+++ b/apollos/src/give/pages/history/index.jsx
@@ -1,6 +1,6 @@
 import { Component, PropTypes} from "react"
 import { connect } from "react-apollo"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import Authorized from "../../../core/blocks/authorzied"
 import { nav as navActions } from "../../../core/store"

--- a/apollos/src/give/pages/now/index.jsx
+++ b/apollos/src/give/pages/now/index.jsx
@@ -1,7 +1,7 @@
 import { Component, PropTypes} from "react"
 import { connect } from "react-apollo"
 import ReactMixin from "react-mixin"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 import { createContainer } from "../../../core/blocks/meteor/react-meteor-data";
 
 import Layout from "./Layout"

--- a/apollos/src/give/pages/schedules/Details/index.jsx
+++ b/apollos/src/give/pages/schedules/Details/index.jsx
@@ -1,6 +1,6 @@
 import { Component, PropTypes} from "react"
 import { connect } from "react-apollo"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import {
   nav as navActions,

--- a/apollos/src/give/pages/schedules/index.jsx
+++ b/apollos/src/give/pages/schedules/index.jsx
@@ -1,6 +1,6 @@
 import { Component, PropTypes} from "react"
 import { connect } from "react-apollo"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import Authorized from "../../../core/blocks/authorzied"
 import {

--- a/apollos/src/give/store/give/saga/index.js
+++ b/apollos/src/give/store/give/saga/index.js
@@ -2,7 +2,7 @@ import "regenerator-runtime/runtime"
 import ReactDOM from "react-dom"
 import Moment from "moment"
 import { take, put, cps, call } from "redux-saga/effects"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import { GraphQL } from "../../../../core/graphql"
 import { addSaga } from "../../../../core/store/utilities"

--- a/apollos/src/profile/pages/home/index.jsx
+++ b/apollos/src/profile/pages/home/index.jsx
@@ -1,6 +1,6 @@
 import { Component, PropTypes} from "react"
 import { connect } from "react-apollo";
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import headerActions from "../../../core/store/header"
 

--- a/apollos/src/profile/pages/settings/HomeAddress/index.jsx
+++ b/apollos/src/profile/pages/settings/HomeAddress/index.jsx
@@ -1,6 +1,6 @@
 import { Component, PropTypes} from "react"
 import { connect } from "react-apollo"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import {
   nav,

--- a/apollos/src/profile/pages/settings/Menu/index.jsx
+++ b/apollos/src/profile/pages/settings/Menu/index.jsx
@@ -1,7 +1,7 @@
 import { Component, PropTypes} from "react"
 import ReactMixin from "react-mixin"
 import { connect } from "react-apollo";
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 import { Link } from "react-router"
 
 import { Headerable } from "../../../../core/mixins/"

--- a/apollos/src/profile/pages/settings/Payments/index.jsx
+++ b/apollos/src/profile/pages/settings/Payments/index.jsx
@@ -1,6 +1,6 @@
 import { Component, PropTypes} from "react"
 import { connect } from "react-apollo"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import { nav } from "../../../../core/store"
 import { Loading } from "../../../../core/components"

--- a/apollos/src/profile/pages/settings/PersonalDetails/index.jsx
+++ b/apollos/src/profile/pages/settings/PersonalDetails/index.jsx
@@ -1,6 +1,6 @@
 import { Component, PropTypes} from "react"
 import { connect } from "react-apollo"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 import Moment from "moment"
 
 import {

--- a/apollos/src/profile/pages/settings/index.jsx
+++ b/apollos/src/profile/pages/settings/index.jsx
@@ -1,6 +1,6 @@
 import { Component } from "react"
 import { connect } from "react-apollo";
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import {
   accounts as accountsActions,

--- a/sites/newspring/imports/components/live/index.jsx
+++ b/sites/newspring/imports/components/live/index.jsx
@@ -1,6 +1,6 @@
 import { Component, PropTypes } from "react";
 import { connect } from "react-apollo";
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 const mapQueriesToProps = ({ ownProps, state }) => {
   return {

--- a/sites/newspring/imports/pages/articles/articles.Single.jsx
+++ b/sites/newspring/imports/pages/articles/articles.Single.jsx
@@ -4,7 +4,7 @@ import { connect } from "react-apollo";
 import { Likeable, Shareable } from "/imports/mixins"
 import Meta from "react-helmet"
 import { VelocityComponent } from "velocity-react"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 // loading state
 import Split, { Left, Right } from "apollos/dist/core/blocks/split"

--- a/sites/newspring/imports/pages/articles/index.jsx
+++ b/sites/newspring/imports/pages/articles/index.jsx
@@ -3,7 +3,7 @@ import ReactMixin from "react-mixin"
 import { Pageable } from "/imports/mixins"
 import { connect } from "react-apollo";
 import { VelocityComponent } from "velocity-react"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import ReactPullToRefresh from "react-pull-to-refresh";
 import { Loading } from "apollos/dist/core/components"

--- a/sites/newspring/imports/pages/devotionals/devotions.Single.jsx
+++ b/sites/newspring/imports/pages/devotionals/devotions.Single.jsx
@@ -4,7 +4,7 @@ import { connect } from "react-apollo";
 import { Likeable, Shareable } from "/imports/mixins"
 import Hammer from "react-hammerjs";
 import { VelocityComponent } from "velocity-react"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import Helpers from "/imports/helpers"
 

--- a/sites/newspring/imports/pages/devotionals/index.jsx
+++ b/sites/newspring/imports/pages/devotionals/index.jsx
@@ -3,7 +3,7 @@ import ReactMixin from "react-mixin";
 import { Pageable } from "/imports/mixins"
 import { connect } from "react-apollo";
 import { VelocityComponent } from "velocity-react"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import ReactPullToRefresh from "react-pull-to-refresh";
 import { Loading } from "apollos/dist/core/components"

--- a/sites/newspring/imports/pages/groups/finder/Filter.jsx
+++ b/sites/newspring/imports/pages/groups/finder/Filter.jsx
@@ -1,7 +1,7 @@
 import { Component } from "react";
 import { connect } from "react-apollo";
 import { withRouter } from "react-router";
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import Loading from "apollos/dist/core/components/loading/index";
 import Forms from "apollos/dist/core/components/forms";

--- a/sites/newspring/imports/pages/groups/finder/Result.jsx
+++ b/sites/newspring/imports/pages/groups/finder/Result.jsx
@@ -1,7 +1,7 @@
 import { Component, PropTypes} from "react";
 import { connect } from "react-apollo";
 import { withRouter } from "react-router";
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import Split, { Left, Right } from "apollos/dist/core/blocks/split";
 import GoogleMap from "apollos/dist/core/components/map";

--- a/sites/newspring/imports/pages/groups/finder/index.jsx
+++ b/sites/newspring/imports/pages/groups/finder/index.jsx
@@ -1,7 +1,7 @@
 import { Component, PropTypes} from "react";
 import { connect } from "react-apollo";
 import ReactMixin from "react-mixin";
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 import { withRouter } from "react-router";
 import Split, { Left, Right } from "apollos/dist/core/blocks/split";
 import { Headerable } from "apollos/dist/core/mixins"

--- a/sites/newspring/imports/pages/groups/index.jsx
+++ b/sites/newspring/imports/pages/groups/index.jsx
@@ -1,6 +1,6 @@
 import { Component, PropTypes} from "react"
 import { connect } from "react-apollo"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import Profile from "./profile/index";
 import Finder from "./finder/index";

--- a/sites/newspring/imports/pages/groups/profile/index.jsx
+++ b/sites/newspring/imports/pages/groups/profile/index.jsx
@@ -1,7 +1,7 @@
 import { Component, PropTypes} from "react";
 import { connect } from "react-apollo";
 import { Link } from "react-router";
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 import GoogleMap from "apollos/dist/core/components/map";
 import Split, { Left, Right } from "apollos/dist/core/blocks/split";
 

--- a/sites/newspring/imports/pages/home/index.jsx
+++ b/sites/newspring/imports/pages/home/index.jsx
@@ -2,7 +2,7 @@ import { Component } from "react"
 import ReactMixin from "react-mixin"
 import { VelocityComponent } from "velocity-react"
 import { connect } from "react-apollo";
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 import { Link } from "react-router";
 import ReactPullToRefresh from "react-pull-to-refresh";
 

--- a/sites/newspring/imports/pages/music/index.jsx
+++ b/sites/newspring/imports/pages/music/index.jsx
@@ -3,7 +3,7 @@ import ReactMixin from "react-mixin"
 import { Pageable } from "/imports/mixins"
 import { connect } from "react-apollo";
 import { VelocityComponent } from "velocity-react"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import ReactPullToRefresh from "react-pull-to-refresh";
 import { Loading } from "apollos/dist/core/components"

--- a/sites/newspring/imports/pages/music/music.Album.jsx
+++ b/sites/newspring/imports/pages/music/music.Album.jsx
@@ -3,7 +3,7 @@ import ReactMixin from "react-mixin"
 import { Likeable, Shareable } from "/imports/mixins"
 import { connect } from "react-apollo";
 import { VelocityComponent } from "velocity-react"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 // loading state
 import { Loading } from "apollos/dist/core/components"

--- a/sites/newspring/imports/pages/series/index.jsx
+++ b/sites/newspring/imports/pages/series/index.jsx
@@ -3,7 +3,7 @@ import ReactMixin from "react-mixin"
 import { Pageable } from "/imports/mixins"
 import { connect } from "react-apollo";
 import { VelocityComponent } from "velocity-react"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import ReactPullToRefresh from "react-pull-to-refresh";
 import { Loading } from "apollos/dist/core/components"

--- a/sites/newspring/imports/pages/series/series.Single.jsx
+++ b/sites/newspring/imports/pages/series/series.Single.jsx
@@ -3,7 +3,7 @@ import ReactMixin from "react-mixin"
 import { Likeable, Shareable } from "/imports/mixins"
 import { connect } from "react-apollo";
 import { VelocityComponent } from "velocity-react"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 // loading state
 import { Loading } from "apollos/dist/core/components"

--- a/sites/newspring/imports/pages/series/series.SingleVideo.jsx
+++ b/sites/newspring/imports/pages/series/series.SingleVideo.jsx
@@ -3,7 +3,7 @@ import ReactMixin from "react-mixin"
 import { Likeable, Shareable } from "/imports/mixins"
 import { connect } from "react-apollo";
 import { VelocityComponent } from "velocity-react"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import Loading from "apollos/dist/core/components/loading"
 import { nav as navActions } from "apollos/dist/core/store"

--- a/sites/newspring/imports/pages/series/series.VideoList.jsx
+++ b/sites/newspring/imports/pages/series/series.VideoList.jsx
@@ -1,6 +1,6 @@
 import { Component, PropTypes } from "react";
 import { connect } from "react-apollo";
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import SeriesVideoListItem from "./series.VideoListItem";
 import { Spinner } from "apollos/dist/core/components/loading"

--- a/sites/newspring/imports/pages/stories/index.jsx
+++ b/sites/newspring/imports/pages/stories/index.jsx
@@ -3,7 +3,7 @@ import ReactMixin from "react-mixin"
 import { Pageable } from "/imports/mixins"
 import { connect } from "react-apollo";
 import { VelocityComponent } from "velocity-react"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 import ReactPullToRefresh from "react-pull-to-refresh";
 import { Loading } from "apollos/dist/core/components"

--- a/sites/newspring/imports/pages/stories/stories.Single.jsx
+++ b/sites/newspring/imports/pages/stories/stories.Single.jsx
@@ -3,7 +3,7 @@ import ReactMixin from "react-mixin"
 import { Likeable, Shareable } from "/imports/mixins"
 import { connect } from "react-apollo";
 import { VelocityComponent } from "velocity-react"
-import gql from "apollo-client/gql";
+import gql from "graphql-tag";
 
 // loading state
 import { Loading } from "apollos/dist/core/components"


### PR DESCRIPTION
`apollo-client/gql` has been deprecated. This uses the new graphql-tag package instead.