### PR TITLE
Live

### DIFF
--- a/apollos/src/core/blocks/global/index.jsx
+++ b/apollos/src/core/blocks/global/index.jsx
@@ -9,6 +9,7 @@ import Modal from "../modal"
 import Meta from "../../components/meta"
 import Nav from "../nav"
 import Header from "../../components/header";
+import Live from "../../components/live";
 
 import {
   accounts as accountsActions,
@@ -35,7 +36,7 @@ export const App = ({ children, className }) => {
       <div className={className}>
         <Meta />
         {(() => { if (process.env.NATIVE) return <Header />; })()}
-        {/*<LivePlayer/>*/}
+        {(() => { if (process.env.NATIVE) return <Live />; })()}
         <div data-status-scroll={true}>
           {children}
         </div>

--- a/apollos/src/core/blocks/global/index.jsx
+++ b/apollos/src/core/blocks/global/index.jsx
@@ -9,7 +9,6 @@ import Modal from "../modal"
 import Meta from "../../components/meta"
 import Nav from "../nav"
 import Header from "../../components/header";
-import Live from "../../components/live";
 
 import {
   accounts as accountsActions,
@@ -36,7 +35,6 @@ export const App = ({ children, className }) => {
       <div className={className}>
         <Meta />
         {(() => { if (process.env.NATIVE) return <Header />; })()}
-        {(() => { if (process.env.NATIVE) return <Live />; })()}
         <div data-status-scroll={true}>
           {children}
         </div>

--- a/apollos/src/core/components/header/index.jsx
+++ b/apollos/src/core/components/header/index.jsx
@@ -3,6 +3,8 @@ import { Component, PropTypes } from "react"
 import { Link } from "react-router"
 import { connect } from "react-redux"
 
+import Live from "../live";
+
 @connect((state) => ({
   color: state.header.content.color || "#6BAC43",
   light: state.header.content.light,
@@ -39,16 +41,19 @@ export default class Header extends Component {
     }
 
     return (
-      <div>
+      <div
+        style={{
+          position: "relative",
+          zIndex: 100
+        }}
+      >
         <div
           className="text-center"
           style={{
             paddingTop: this.props.isSearch ? "0px" : "15px",
             paddingBottom: this.props.isSearch ? "0px" : "15px",
             backgroundColor: this.props.color,
-            borderBottom: "1px solid rgba(0,0,0, 0.1)",
-            position: "relative",
-            zIndex: 100
+            borderBottom: "1px solid rgba(0,0,0, 0.1)"
           }}
         >
           {(() => {
@@ -122,6 +127,7 @@ export default class Header extends Component {
             );
           };
         })()}
+        <Live />
       </div>
     )
   }

--- a/apollos/src/core/components/header/index.jsx
+++ b/apollos/src/core/components/header/index.jsx
@@ -37,7 +37,7 @@ export default class Header extends Component {
     }
 
     if (!this.props.visible) {
-      return null;
+      return <Live />;
     }
 
     return (

--- a/apollos/src/core/components/live/index.jsx
+++ b/apollos/src/core/components/live/index.jsx
@@ -12,7 +12,7 @@ const mapQueriesToProps = ({ ownProps, state }) => {
       query: gql`query IsLive {
         live {
           live
-          streamUrl
+          embedCode
         }
       }`,
       forceFetch: false,
@@ -53,7 +53,7 @@ export default class Live extends Component {
   }
 
   render () {
-    const { live, streamUrl } = this.props.data;
+    const { live, embedCode } = this.props.data;
 
     if (!this.props.live.show) return <div />
 

--- a/apollos/src/core/components/live/index.jsx
+++ b/apollos/src/core/components/live/index.jsx
@@ -1,6 +1,9 @@
 import { Component, PropTypes } from "react";
 import { connect } from "react-apollo";
 import gql from "graphql-tag";
+import { css } from "aphrodite";
+
+import Styles from "./live-css";
 
 const mapQueriesToProps = ({ ownProps, state }) => {
   return {
@@ -18,14 +21,33 @@ const mapQueriesToProps = ({ ownProps, state }) => {
   };
 };
 
-@connect({ mapQueriesToProps })
+const mapStateToProps = (state) => ({ live: state.live });
+
+@connect({ mapQueriesToProps, mapStateToProps })
 export default class Live extends Component {
+
+  getClasses = () => {
+    const classes = [
+      "background--secondary",
+      "text-center",
+      "soft-half-ends",
+    ];
+
+    if (this.props.live.float) {
+      classes.push(css(Styles["live-float"]));
+    }
+
+    return classes.join(" ");
+  }
+
   render () {
     const { live, streamUrl } = this.props.data;
 
+    if (!this.props.live.show) return <div />
+
     return (
       <div
-        className="background--secondary text-center soft-half-ends"
+        className={this.getClasses()}
       >
         <h7 className="text-light-primary flush hard">
           NewSpring Church Live, Watch Now!

--- a/apollos/src/core/components/live/index.jsx
+++ b/apollos/src/core/components/live/index.jsx
@@ -21,32 +21,15 @@ const mapQueriesToProps = ({ ownProps, state }) => {
 @connect({ mapQueriesToProps })
 export default class Live extends Component {
   render () {
-    // const { live } = this.props.data;
+    const { live, streamUrl } = this.props.data;
 
     return (
       <div
-        className="locked-top locked-sides background--secondary text-center"
-        style={{
-          zIndex: 999,
-          opacity: .9,
-          paddingTop: "5px",
-          paddingBottom: "5px",
-          top: "45px",
-        }}
+        className="background--secondary text-center soft-half-ends"
       >
-        <p className="text-light-primary flush hard"><small><em>
-          Streaming Live - Watch Now
-          <span
-            className="icon-arrow-next"
-            style={{
-              display: "12px",
-              fontSize: "12px",
-              marginLeft: "7px",
-            }}
-          >
-
-          </span>
-        </em></small></p>
+        <h7 className="text-light-primary flush hard">
+          NewSpring Church Live, Watch Now!
+        </h7>
       </div>
     )
   }

--- a/apollos/src/core/components/live/index.jsx
+++ b/apollos/src/core/components/live/index.jsx
@@ -29,14 +29,25 @@ export default class Live extends Component {
 
   getClasses = () => {
     const classes = [
-      "background--secondary",
       "text-center",
       "soft-half-ends",
+      css(Styles["live-banner"])
     ];
 
     if (this.props.live.float) {
       classes.push(css(Styles["live-float"]));
     }
+
+    return classes.join(" ");
+  }
+
+  getTextClasses = () => {
+    const classes = [
+      "flush",
+      "hard",
+      "text-light-primary",
+      css(Styles["live-text"])
+    ];
 
     return classes.join(" ");
   }
@@ -57,7 +68,7 @@ export default class Live extends Component {
               className={this.getClasses()}
               style={interpolatingStyle}
             >
-              <h7 className="text-light-primary flush hard">
+              <h7 className={this.getTextClasses()}>
                 NewSpring Church Live, Watch Now!
               </h7>
             </div>

--- a/apollos/src/core/components/live/index.jsx
+++ b/apollos/src/core/components/live/index.jsx
@@ -2,6 +2,7 @@ import { Component, PropTypes } from "react";
 import { connect } from "react-apollo";
 import gql from "graphql-tag";
 import { css } from "aphrodite";
+import { Motion, spring } from "react-motion";
 
 import Styles from "./live-css";
 
@@ -46,13 +47,23 @@ export default class Live extends Component {
     if (!this.props.live.show) return <div />
 
     return (
-      <div
-        className={this.getClasses()}
+      <Motion
+        defaultStyle={{height: 0}}
+        style={{height: spring(40)}}
       >
-        <h7 className="text-light-primary flush hard">
-          NewSpring Church Live, Watch Now!
-        </h7>
-      </div>
+        {interpolatingStyle => {
+          return (
+            <div
+              className={this.getClasses()}
+              style={interpolatingStyle}
+            >
+              <h7 className="text-light-primary flush hard">
+                NewSpring Church Live, Watch Now!
+              </h7>
+            </div>
+          );
+        }}
+      </Motion>
     )
   }
 }

--- a/apollos/src/core/components/live/index.jsx
+++ b/apollos/src/core/components/live/index.jsx
@@ -2,6 +2,7 @@ import { Component, PropTypes } from "react";
 import { connect } from "react-apollo";
 import gql from "graphql-tag";
 import { css } from "aphrodite";
+import { Link } from "react-router";
 import { Motion, spring } from "react-motion";
 
 import Styles from "./live-css";
@@ -31,6 +32,9 @@ export default class Live extends Component {
     const classes = [
       "text-center",
       "soft-half-ends",
+      "display-inline-block",
+      "plain",
+      "one-whole",
       css(Styles["live-banner"])
     ];
 
@@ -64,14 +68,15 @@ export default class Live extends Component {
       >
         {interpolatingStyle => {
           return (
-            <div
+            <Link
+              to={`/video/${embedCode}`}
               className={this.getClasses()}
               style={interpolatingStyle}
             >
               <h7 className={this.getTextClasses()}>
                 NewSpring Church Live, Watch Now!
               </h7>
-            </div>
+            </Link>
           );
         }}
       </Motion>

--- a/apollos/src/core/components/live/index.jsx
+++ b/apollos/src/core/components/live/index.jsx
@@ -7,22 +7,13 @@ const mapQueriesToProps = ({ ownProps, state }) => {
     data: {
       query: gql`query IsLive {
         live {
-          title
           live
-          media {
-            streamUrl
-          }
-          content {
-            description
-            body
-            images {
-              cloudfront
-            }
-          }
+          streamUrl
         }
       }`,
       forceFetch: false,
       returnPartialData: false,
+      pollInterval: 60000,
     },
   };
 };
@@ -30,7 +21,7 @@ const mapQueriesToProps = ({ ownProps, state }) => {
 @connect({ mapQueriesToProps })
 export default class Live extends Component {
   render () {
-    const { live } = this.props.data;
+    // const { live } = this.props.data;
 
     return (
       <div

--- a/apollos/src/core/components/live/index.jsx
+++ b/apollos/src/core/components/live/index.jsx
@@ -7,6 +7,8 @@ import { Motion, spring } from "react-motion";
 
 import Styles from "./live-css";
 
+import liveActions from "apollos/dist/core/store/live";
+
 const mapQueriesToProps = ({ ownProps, state }) => {
   return {
     data: {
@@ -35,7 +37,7 @@ export default class Live extends Component {
       "display-inline-block",
       "plain",
       "one-whole",
-      css(Styles["live-banner"])
+      css(Styles["live-banner"]),
     ];
 
     if (this.props.live.float) {
@@ -50,16 +52,40 @@ export default class Live extends Component {
       "flush",
       "hard",
       "text-light-primary",
-      css(Styles["live-text"])
+      css(Styles["live-text"]),
     ];
 
     return classes.join(" ");
   }
 
-  render () {
-    const { live, embedCode } = this.props.data;
+  componentWillUpdate(nextProps, nextState) {
+    this.handleLiveChange(nextProps, nextState);
+  }
 
-    if (!this.props.live.show) return <div />
+  handleLiveChange = (nextProps) => {
+    const { live } = nextProps.data;
+    if (!live) return;
+
+    const isLive = live.live;
+    const embedCode = live.embedCode;
+
+    if (
+      isLive === nextProps.live.live &&
+      embedCode === nextProps.live.embedCode
+    ) {
+      return;
+    }
+
+    if (isLive) {
+      this.props.dispatch(liveActions.set({ isLive, embedCode }));
+    } else {
+      this.props.dispatch(liveActions.reset());
+    }
+  }
+
+  render () {
+    const { live, show, embedCode } = this.props.live;
+    if (!live || !show || !embedCode) return null;
 
     return (
       <Motion

--- a/apollos/src/core/components/live/live-css.js
+++ b/apollos/src/core/components/live/live-css.js
@@ -1,0 +1,10 @@
+import { StyleSheet } from "aphrodite";
+
+export default StyleSheet.create({
+  "live-float": {
+    position: "absolute",
+    top: "45px",
+    width: "100%",
+    zIndex: 1,
+  },
+});

--- a/apollos/src/core/components/live/live-css.js
+++ b/apollos/src/core/components/live/live-css.js
@@ -1,5 +1,37 @@
 import { StyleSheet } from "aphrodite";
 
+const keyframes = {
+  "0%": {
+    backgroundColor: "#5DA23D",
+  },
+  "50%": {
+    backgroundColor: "#3F803C",
+  },
+  "100%": {
+    backgroundColor: "#5DA23D",
+  },
+};
+
+const animation = {
+  animationDuration: "10s",
+  animationIterationCount: "infinite",
+  animationName: keyframes,
+  animationTimingFunction: "cubic-bezier(0.66, 0.21, 0.49, 0.88)",
+}
+
+const phaders = {
+  "from": {
+    opacity: 0,
+  }
+}
+
+const textAnimation = {
+  animationDuration: "1.5s",
+  animationIterationCount: "infinite",
+  animationName: phaders,
+  animationDirection: "alternate",
+}
+
 export default StyleSheet.create({
   "live-float": {
     position: "absolute",
@@ -7,4 +39,6 @@ export default StyleSheet.create({
     width: "100%",
     zIndex: 1,
   },
+  "live-banner": animation,
+  "live-text": textAnimation,
 });

--- a/apollos/src/core/components/pullToRefresh/index.jsx
+++ b/apollos/src/core/components/pullToRefresh/index.jsx
@@ -4,7 +4,8 @@ import { connect } from "react-apollo";
 import ReactPullToRefresh from "react-pull-to-refresh";
 
 const mapStateToProps = (state) => ({
-  isLive: state.live.show,
+  isLive: state.live.live,
+  show: state.live.show,
 });
 
 @connect({ mapStateToProps })
@@ -16,12 +17,14 @@ export default class ApollosPullToRefresh extends Component {
 
   render() {
 
+    const liveBannerVisible = this.props.isLive && this.props.show;
+
     return (
       <div>
         <div className="ptr-fake-background">
         </div>
 
-        {(() => { if (this.props.isLive) return (
+        {(() => { if (liveBannerVisible) return (
           <style>
             {".ptr-element i {\
               top: 100px;\

--- a/apollos/src/core/components/pullToRefresh/index.jsx
+++ b/apollos/src/core/components/pullToRefresh/index.jsx
@@ -1,0 +1,44 @@
+import { Component, PropTypes } from "react"
+import ReactMixin from "react-mixin"
+import { connect } from "react-apollo";
+import ReactPullToRefresh from "react-pull-to-refresh";
+
+const mapStateToProps = (state) => ({
+  isLive: state.live.show,
+});
+
+@connect({ mapStateToProps })
+export default class ApollosPullToRefresh extends Component {
+
+  static propTypes = {
+    handleRefresh: PropTypes.func.isRequired,
+  }
+
+  render() {
+
+    return (
+      <div>
+        <div className="ptr-fake-background">
+        </div>
+
+        {(() => { if (this.props.isLive) return (
+          <style>
+            {".ptr-element i {\
+              top: 100px;\
+            }"}
+          </style>
+        ); })()}
+
+        <ReactPullToRefresh
+          onRefresh={this.props.handleRefresh}
+          icon={<i className="icon-leaf-outline"></i>}
+          loading={<i className="loading icon-leaf-outline"></i>}
+        >
+          {this.props.children}
+        </ReactPullToRefresh>
+      </div>
+    );
+
+  };
+
+};

--- a/apollos/src/core/store/header/saga.js
+++ b/apollos/src/core/store/header/saga.js
@@ -3,7 +3,7 @@ import { fork, put, cps, select } from "redux-saga/effects"
 import { addSaga } from "../utilities"
 
 const canRun = (
-  typeof window !== "undefined" && window !== null && window.StatusBar
+  typeof window !== "undefined" && window !== null && window.StatusBar !== "undefined"
 );
 
 function* toggleHeader() {
@@ -26,6 +26,9 @@ function* setColor({ color }) {
 function* setColorFromHeader() {
   console.log("setColorFromHeader");
   let { header } = yield select()
+  console.log(header);
+  console.log(header.content.color);
+  console.log(canRun);
   if (canRun && header.content.color) {
     console.log("setColorFromHeader can run");
     console.log(header);

--- a/apollos/src/core/store/header/saga.js
+++ b/apollos/src/core/store/header/saga.js
@@ -7,32 +7,20 @@ const canRun = (
 );
 
 function* toggleHeader() {
-  console.log("toggleHeader");
   let { header } = yield select()
-  console.log(header);
-  console.log(header.statusBar);
   if (canRun) {
-    console.log("toggleHeader can run");
     if (!header.statusBar) StatusBar.hide()
     if (header.statusBar) StatusBar.show()
   }
 };
 
 function* setColor({ color }) {
-  console.log("setColor", color);
   if (canRun && color) StatusBar.backgroundColorByHexString(color);
 };
 
 function* setColorFromHeader() {
-  console.log("setColorFromHeader");
   let { header } = yield select()
-  console.log(header);
-  console.log(header.content.color);
-  console.log(canRun);
   if (canRun && header.content.color) {
-    console.log("setColorFromHeader can run");
-    console.log(header);
-    console.log(header.content.color);
     StatusBar.backgroundColorByHexString(header.content.color);
   }
 };

--- a/apollos/src/core/store/header/saga.js
+++ b/apollos/src/core/store/header/saga.js
@@ -7,20 +7,29 @@ const canRun = (
 );
 
 function* toggleHeader() {
+  console.log("toggleHeader");
   let { header } = yield select()
+  console.log(header);
+  console.log(header.statusBar);
   if (canRun) {
+    console.log("toggleHeader can run");
     if (!header.statusBar) StatusBar.hide()
     if (header.statusBar) StatusBar.show()
   }
 };
 
 function* setColor({ color }) {
+  console.log("setColor", color);
   if (canRun && color) StatusBar.backgroundColorByHexString(color);
 };
 
 function* setColorFromHeader() {
+  console.log("setColorFromHeader");
   let { header } = yield select()
   if (canRun && header.content.color) {
+    console.log("setColorFromHeader can run");
+    console.log(header);
+    console.log(header.content.color);
     StatusBar.backgroundColorByHexString(header.content.color);
   }
 };

--- a/apollos/src/core/store/header/saga.js
+++ b/apollos/src/core/store/header/saga.js
@@ -7,20 +7,25 @@ const canRun = (
 );
 
 function* toggleHeader() {
+  console.log("toggleHeader");
   let { header } = select()
   if (canRun) {
+    console.log("toggleHeader can run");
     if (!header.statusBar) StatusBar.hide()
     if (header.statusBar) StatusBar.show()
   }
 };
 
 function* setColor({ color }) {
+  console.log("setColor", color);
   if (canRun && color) StatusBar.backgroundColorByHexString(color);
 };
 
 function* setColorFromHeader() {
   let { header } = select()
+  console.log("setColorFromHeader", header);
   if (canRun && header.content.color) {
+    console.log("setColorFromHeader can run");
     StatusBar.backgroundColorByHexString(header.content.color);
   }
 };

--- a/apollos/src/core/store/header/saga.js
+++ b/apollos/src/core/store/header/saga.js
@@ -8,7 +8,7 @@ const canRun = (
 
 function* toggleHeader() {
   console.log("toggleHeader");
-  let { header } = select()
+  let { header } = yield select()
   if (canRun) {
     console.log("toggleHeader can run");
     if (!header.statusBar) StatusBar.hide()
@@ -22,7 +22,7 @@ function* setColor({ color }) {
 };
 
 function* setColorFromHeader() {
-  let { header } = select()
+  let { header } = yield select()
   console.log("setColorFromHeader", header);
   if (canRun && header.content.color) {
     console.log("setColorFromHeader can run");

--- a/apollos/src/core/store/header/saga.js
+++ b/apollos/src/core/store/header/saga.js
@@ -6,7 +6,7 @@ const canRun = (
   typeof window !== "undefined" && window !== null && window.StatusBar
 );
 
-function* toogleHeader() {
+function* toggleHeader() {
   let { header } = select()
   if (canRun) {
     if (!header.statusBar) StatusBar.hide()
@@ -14,11 +14,11 @@ function* toogleHeader() {
   }
 };
 
-function* setColor({ color}) {
+function* setColor({ color }) {
   if (canRun && color) StatusBar.backgroundColorByHexString(color);
 };
 
-function* toogleHeader() {
+function* setColorFromHeader() {
   let { header } = select()
   if (canRun && header.content.color) {
     StatusBar.backgroundColorByHexString(header.content.color);
@@ -26,7 +26,7 @@ function* toogleHeader() {
 };
 
 addSaga(function* headerSaga() {
-  yield fork(takeLatest, "HEADER.TOGGLE_VISIBILITY", toogleHeader);
+  yield fork(takeLatest, "HEADER.TOGGLE_VISIBILITY", toggleHeader);
   yield fork(takeLatest, "STATUSBAR.SET", setColor);
-  yield fork(takeLatest, "HEADER.SET", setColor)
+  yield fork(takeLatest, "HEADER.SET", setColorFromHeader)
 })

--- a/apollos/src/core/store/header/saga.js
+++ b/apollos/src/core/store/header/saga.js
@@ -7,25 +7,20 @@ const canRun = (
 );
 
 function* toggleHeader() {
-  console.log("toggleHeader");
   let { header } = yield select()
   if (canRun) {
-    console.log("toggleHeader can run");
     if (!header.statusBar) StatusBar.hide()
     if (header.statusBar) StatusBar.show()
   }
 };
 
 function* setColor({ color }) {
-  console.log("setColor", color);
   if (canRun && color) StatusBar.backgroundColorByHexString(color);
 };
 
 function* setColorFromHeader() {
   let { header } = yield select()
-  console.log("setColorFromHeader", header);
   if (canRun && header.content.color) {
-    console.log("setColorFromHeader can run");
     StatusBar.backgroundColorByHexString(header.content.color);
   }
 };

--- a/apollos/src/core/store/index.js
+++ b/apollos/src/core/store/index.js
@@ -9,6 +9,7 @@ import search from "./search";
 import sections from "./sections";
 import share from "./share";
 import liked from "./liked";
+import live from "./live";
 import topics from "./topics";
 
 let header;
@@ -28,6 +29,7 @@ export {
   sections,
   share,
   liked,
+  live,
   topics,
   header,
 

--- a/apollos/src/core/store/live/index.js
+++ b/apollos/src/core/store/live/index.js
@@ -1,0 +1,28 @@
+/*
+
+
+  Live action types
+
+  LIVE.SHOW
+    show live bar
+
+  LIVE.HIDE
+    hide live bar
+
+  LIVE.FLOAT
+    float live bar for special cases
+
+*/
+import reducer from "./reducer"
+import { addReducer } from "../utilities"
+
+addReducer({
+  live: reducer
+})
+
+export default {
+  show: () => ({ type: "LIVE.SHOW" }),
+  hide: () => ({ type: "LIVE.HIDE" }),
+  float: () => ({ type: "LIVE.FLOAT" }),
+  unfloat: () => ({ type: "LIVE.UNFLOAT" }),
+}

--- a/apollos/src/core/store/live/index.js
+++ b/apollos/src/core/store/live/index.js
@@ -3,6 +3,12 @@
 
   Live action types
 
+  LIVE.SET
+    set live status and embed code
+
+  LIVE.RESET
+    reset live status and embed code
+
   LIVE.SHOW
     show live bar
 
@@ -21,6 +27,8 @@ addReducer({
 })
 
 export default {
+  set: ({ isLive, embedCode }) => ({ type: "LIVE.SET", isLive, embedCode }),
+  reset: () => ({ type: "LIVE.RESET" }),
   show: () => ({ type: "LIVE.SHOW" }),
   hide: () => ({ type: "LIVE.HIDE" }),
   float: () => ({ type: "LIVE.FLOAT" }),

--- a/apollos/src/core/store/live/reducer.js
+++ b/apollos/src/core/store/live/reducer.js
@@ -7,11 +7,27 @@
 import { createReducer } from "../utilities"
 
 const initial = {
+  live: false,
+  embedCode: null,
   show: true,
   float: false,
 }
 
 export default createReducer(initial, {
+
+  ["LIVE.SET"](state, action) {
+    return {...state, ...{
+      live: action.isLive,
+      embedCode: action.embedCode,
+    } };
+  },
+
+  ["LIVE.RESET"](state, action) {
+    return {...state, ...{
+      live: initial.live,
+      embedCode: initial.embedCode,
+    } };
+  },
 
   ["LIVE.SHOW"](state, action) {
     return {...state, ...{

--- a/apollos/src/core/store/live/reducer.js
+++ b/apollos/src/core/store/live/reducer.js
@@ -1,0 +1,40 @@
+/*
+
+  Live store
+
+*/
+
+import { createReducer } from "../utilities"
+
+const initial = {
+  show: true,
+  float: false,
+}
+
+export default createReducer(initial, {
+
+  ["LIVE.SHOW"](state, action) {
+    return {...state, ...{
+      show: true,
+    } };
+  },
+
+  ["LIVE.HIDE"](state, action) {
+    return {...state, ...{
+      show: false,
+    } };
+  },
+
+  ["LIVE.FLOAT"](state, action) {
+    return {...state, ...{
+      float: true,
+    } };
+  },
+
+  ["LIVE.UNFLOAT"](state, action) {
+    return {...state, ...{
+      float: false,
+    } };
+  },
+
+});

--- a/sites/newspring/imports/components/players/video/index.jsx
+++ b/sites/newspring/imports/components/players/video/index.jsx
@@ -59,7 +59,7 @@ export default class VideoPlayer extends Component {
       "playerBrandingId": "ZmJmNTVlNDk1NjcwYTVkMzAzODkyMjg0",
       "autoplay": true,
       "skin": {
-        "config": "http://ns.ops.s3.amazonaws.com/player/skin.new.json",
+        "config": "//ns-ops.s3.amazonaws.com/player/skin.new.json",
         "inline": {"shareScreen": {"embed": {"source": "<iframe width='640' height='480' frameborder='0' allowfullscreen src='//player.ooyala.com/static/v4/stable/4.5.5/skin-plugin/iframe.html?ec=<ASSET_ID>&pbid=<PLAYER_ID>&pcode=<PUBLISHER_ID>'></iframe>"}}}
       },
       onCreate: (player) => {

--- a/sites/newspring/imports/components/players/video/index.jsx
+++ b/sites/newspring/imports/components/players/video/index.jsx
@@ -60,7 +60,7 @@ export default class VideoPlayer extends Component {
       "autoplay": true,
       "skin": {
         "config": "http://ns.ops.s3.amazonaws.com/player/skin.new.json",
-        "inline": {"shareScreen": {"embed": {"source": "<iframe width='640' height='480' frameborder='0' allowfullscreen src='//player.ooyala.com/static/v4/stable/4.4.11/skin-plugin/iframe.html?ec=<ASSET_ID>&pbid=<PLAYER_ID>&pcode=<PUBLISHER_ID>'></iframe>"}}}
+        "inline": {"shareScreen": {"embed": {"source": "<iframe width='640' height='480' frameborder='0' allowfullscreen src='//player.ooyala.com/static/v4/stable/4.5.5/skin-plugin/iframe.html?ec=<ASSET_ID>&pbid=<PLAYER_ID>&pcode=<PUBLISHER_ID>'></iframe>"}}}
       },
       onCreate: (player) => {
         // bind message bus for reporting analaytics

--- a/sites/newspring/imports/index.js
+++ b/sites/newspring/imports/index.js
@@ -24,9 +24,10 @@ if (process.env.NATIVE) {
   // sync load ooyala scripts
   // XXX can we move this to just the video component?
   @scriptLoader(
-    "//player.ooyala.com/static/v4/stable/4.4.11/core.min.js",
-    "//player.ooyala.com/static/v4/stable/4.4.11/video-plugin/main_html5.js",
-    "//player.ooyala.com/static/v4/stable/4.4.11/skin-plugin/html5-skin.js",
+    "//player.ooyala.com/static/v4/stable/4.5.5/core.min.js",
+    "//player.ooyala.com/static/v4/stable/4.5.5/video-plugin/main_html5.min.js",
+    "//player.ooyala.com/static/v4/stable/4.5.5/skin-plugin/html5-skin.js",
+    "//player.ooyala.com/static/v4/stable/4.5.5/video-plugin/bit_wrapper.min.js",
   )
   @connect((state) => ({ audio: state.audio }))
   class AppGlobal extends Component {

--- a/sites/newspring/imports/index.js
+++ b/sites/newspring/imports/index.js
@@ -18,17 +18,20 @@ let App = null;
 if (process.env.NATIVE) {
   import scriptLoader from "react-async-script-loader";
   import AudioPlayer from "/imports/components/players/audio/index"
-  // XXX add live query back to heighliner
-  // import LivePlayer from "/imports/components/live/index"
 
   // sync load ooyala scripts
   // XXX can we move this to just the video component?
-  @scriptLoader(
+  const scripts = [
     "//player.ooyala.com/static/v4/stable/4.5.5/core.min.js",
     "//player.ooyala.com/static/v4/stable/4.5.5/video-plugin/main_html5.min.js",
     "//player.ooyala.com/static/v4/stable/4.5.5/skin-plugin/html5-skin.js",
-    "//player.ooyala.com/static/v4/stable/4.5.5/video-plugin/bit_wrapper.min.js",
-  )
+  ];
+  if (Meteor.isCordova) {
+    scripts.push(
+      "//player.ooyala.com/static/v4/stable/4.5.5/video-plugin/bit_wrapper.min.js"
+    );
+  }
+  @scriptLoader(...scripts)
   @connect((state) => ({ audio: state.audio }))
   class AppGlobal extends Component {
     render() {
@@ -43,7 +46,6 @@ if (process.env.NATIVE) {
 
       return (
         <Global className={classes.join(" ")}>
-          {/*<LivePlayer/>*/}
           {this.props.children}
           <AudioPlayer propVal={visibility}/>
         </Global>

--- a/sites/newspring/imports/pages/articles/index.jsx
+++ b/sites/newspring/imports/pages/articles/index.jsx
@@ -5,12 +5,12 @@ import { connect } from "react-apollo";
 import { VelocityComponent } from "velocity-react"
 import gql from "graphql-tag";
 
-import ReactPullToRefresh from "react-pull-to-refresh";
 import { Loading } from "apollos/dist/core/components"
 
 import { FeedItemSkeleton } from "apollos/dist/core/components/loading"
 import { Headerable } from "apollos/dist/core/mixins"
 import { nav as navActions } from "apollos/dist/core/store"
+import ApollosPullToRefresh from "apollos/dist/core/components/pullToRefresh";
 
 import Single from "./articles.Single"
 
@@ -101,25 +101,15 @@ class Template extends Component {
         duration={1000}
         runOnMount={true}
       >
-        <div>
-          <div className="ptr-fake-background"></div>
-
-          <ReactPullToRefresh
-            onRefresh={this.handleRefresh}
-            icon={<i className="icon-leaf-outline"></i>}
-            loading={<i className="loading icon-leaf-outline"></i>}
-          >
-
-            <div className="soft@portable soft-double@lap-and-up background--light-primary">
-              <section className="soft-half">
-                <div className="grid">
-                  {this.renderItems()}
-                </div>
-              </section>
-            </div>
-
-          </ReactPullToRefresh>
-        </div>
+        <ApollosPullToRefresh handleRefresh={this.handleRefresh}>
+          <div className="soft@portable soft-double@lap-and-up background--light-primary">
+            <section className="soft-half">
+              <div className="grid">
+                {this.renderItems()}
+              </div>
+            </section>
+          </div>
+        </ApollosPullToRefresh>
       </VelocityComponent>
     );
 

--- a/sites/newspring/imports/pages/devotionals/devotions.Single.jsx
+++ b/sites/newspring/imports/pages/devotionals/devotions.Single.jsx
@@ -66,7 +66,7 @@ const mapQueriesToProps = ({ ownProps, state }) => {
       query: gql`query IsLive {
         live {
           live
-          streamUrl
+          embedCode
         }
       }`,
       forceFetch: false,

--- a/sites/newspring/imports/pages/devotionals/devotions.Single.jsx
+++ b/sites/newspring/imports/pages/devotionals/devotions.Single.jsx
@@ -71,7 +71,6 @@ const mapQueriesToProps = ({ ownProps, state }) => {
       }`,
       forceFetch: false,
       returnPartialData: false,
-      pollInterval: 60000,
     },
   };
 };

--- a/sites/newspring/imports/pages/devotionals/devotions.Single.jsx
+++ b/sites/newspring/imports/pages/devotionals/devotions.Single.jsx
@@ -62,20 +62,13 @@ const mapQueriesToProps = ({ ownProps, state }) => {
       forceFetch: false,
       returnPartialData: false,
     },
-    live: {
-      query: gql`query IsLive {
-        live {
-          live
-          embedCode
-        }
-      }`,
-      forceFetch: false,
-      returnPartialData: false,
-    },
   };
 };
 
-const mapStateToProps = (state) => ({ modal: { visible: state.modal.visible }});
+const mapStateToProps = (state) => ({
+  modal: { visible: state.modal.visible },
+  live: state.live,
+});
 
 @connect({ mapQueriesToProps, mapStateToProps })
 @ReactMixin.decorate(Likeable)
@@ -129,9 +122,7 @@ export default class SeriesSingle extends Component {
   handleLiveBar = (props, state) => {
     const { liveSet } = state;
     const { content } = props.devotion;
-    // XXX
-    // const { live } = props.live;
-    const live = true;
+    const { live } = props.live;
 
     if (liveSet || !live || !content) return;
 
@@ -156,9 +147,7 @@ export default class SeriesSingle extends Component {
 
   getLiveClasses = () => {
     const classes = [];
-    // XXX
-    // if (this.props.live.live && this.state.livePush) {
-    if (true && this.state.livePush) {
+    if (this.props.live.live && this.state.livePush) {
       classes.push("push-double-top");
     }
 

--- a/sites/newspring/imports/pages/devotionals/devotions.Single.jsx
+++ b/sites/newspring/imports/pages/devotionals/devotions.Single.jsx
@@ -88,6 +88,7 @@ export default class SeriesSingle extends Component {
     event.preventDefault();
     this.setState({
       selectedIndex: 1,
+      liveSet: false,
       livePush: false,
     });
   }
@@ -95,7 +96,11 @@ export default class SeriesSingle extends Component {
   componentWillMount() {
     if (process.env.WEB) return;
 
-    this.handleLiveBar();
+    // hide the live bar and then bring it back
+    // after the view has faded in. this prevents
+    // an issue with the z-index and the arrow
+    // from the header.
+    this.props.dispatch(liveActions.hide());
 
     this.props.dispatch(navActions.setLevel("CONTENT"));
     this.props.dispatch(navActions.setAction("CONTENT", {
@@ -107,29 +112,40 @@ export default class SeriesSingle extends Component {
   }
 
   componentWillUnmount() {
+    if (process.env.WEB) return;
     this.props.dispatch(liveActions.unfloat());
   }
 
-  // hide the live bar and then bring it back
-  // after the view has faded in. this prevents
-  // an issue with the z-index and the arrow
-  // from the header.
-  //
-  // also, apply float styles to the bar so it
+  // if has scripture and live re-enabled
+  // the live bar
+  // else apply float styles to the bar so it
   // will display below the fixed header
-  handleLiveBar = () => {
+  componentWillUpdate(nextProps, nextState) {
+    const { liveSet } = nextState;
+    const { content } = nextProps.devotion;
     // XXX
-    // handle case when there's no scripture
-    // if (!this.props.live.live) return;
-    if (!true) return;
-    this.props.dispatch(liveActions.hide());
-    this.props.dispatch(liveActions.float());
-    setTimeout(() => {
-      this.setState({
-        livePush: true,
-      });
-      this.props.dispatch(liveActions.show());
-    }, 1000);
+    // const { live } = nextProps.live;
+    const live = true;
+
+    if (liveSet || !live || !content) return;
+
+    this.setState({
+      liveSet: true,
+    });
+
+    if (content.content.scripture) {
+      this.props.dispatch(liveActions.float());
+      setTimeout(() => {
+        this.setState({
+          livePush: true,
+        });
+        this.props.dispatch(liveActions.show());
+      }, 1000);
+    } else {
+      setTimeout(() => {
+        this.props.dispatch(liveActions.show());
+      }, 1000);
+    }
   }
 
   getLiveClasses = () => {

--- a/sites/newspring/imports/pages/devotionals/devotions.Single.jsx
+++ b/sites/newspring/imports/pages/devotionals/devotions.Single.jsx
@@ -101,6 +101,8 @@ export default class SeriesSingle extends Component {
     // an issue with the z-index and the arrow
     // from the header.
     this.props.dispatch(liveActions.hide());
+    // for cached data
+    this.handleLiveBar(this.props, this.state);
 
     this.props.dispatch(navActions.setLevel("CONTENT"));
     this.props.dispatch(navActions.setAction("CONTENT", {
@@ -116,15 +118,19 @@ export default class SeriesSingle extends Component {
     this.props.dispatch(liveActions.unfloat());
   }
 
+  componentWillUpdate(nextProps, nextState) {
+    this.handleLiveBar(nextProps, nextState);
+  }
+
   // if has scripture and live re-enabled
   // the live bar
   // else apply float styles to the bar so it
   // will display below the fixed header
-  componentWillUpdate(nextProps, nextState) {
-    const { liveSet } = nextState;
-    const { content } = nextProps.devotion;
+  handleLiveBar = (props, state) => {
+    const { liveSet } = state;
+    const { content } = props.devotion;
     // XXX
-    // const { live } = nextProps.live;
+    // const { live } = props.live;
     const live = true;
 
     if (liveSet || !live || !content) return;

--- a/sites/newspring/imports/pages/devotionals/devotions.SingleContent.jsx
+++ b/sites/newspring/imports/pages/devotionals/devotions.SingleContent.jsx
@@ -33,6 +33,9 @@ export default class DevotionsSingleContent extends Component {
     return (
       <section
         className={this.getClasses()}
+        style={{
+          transition: "0.7s margin",
+        }}
         data-status-scroll-item={true}
       >
           <div

--- a/sites/newspring/imports/pages/devotionals/devotions.SingleContent.jsx
+++ b/sites/newspring/imports/pages/devotionals/devotions.SingleContent.jsx
@@ -11,6 +11,20 @@ export default class DevotionsSingleContent extends Component {
     devotion: PropTypes.object.isRequired
   }
 
+  getClasses = () => {
+    let classes = [
+      "hard-sides",
+      "hard-top",
+      "background--light-primary",
+    ];
+
+    if (this.props.classes) {
+      classes = classes.concat(this.props.classes);
+    }
+
+    return classes.join(" ");
+  }
+
   render() {
 
     const devotion = this.props.devotion;
@@ -18,7 +32,7 @@ export default class DevotionsSingleContent extends Component {
     // `data-status-scroll-container` is set in the react-swipe-views module
     return (
       <section
-        className="hard-sides hard-top background--light-primary"
+        className={this.getClasses()}
         data-status-scroll-item={true}
       >
           <div

--- a/sites/newspring/imports/pages/devotionals/devotions.SingleScripture.jsx
+++ b/sites/newspring/imports/pages/devotionals/devotions.SingleScripture.jsx
@@ -10,6 +10,20 @@ export default class DevotionsSingleScripture extends Component {
     devotion: PropTypes.object.isRequired
   }
 
+  getClasses = () => {
+    let classes = [
+      "hard-sides",
+      "hard-top",
+      "background--light-primary",
+    ];
+
+    if (this.props.classes) {
+      classes = classes.concat(this.props.classes);
+    }
+
+    return classes.join(" ");
+  }
+
   render() {
 
     const devotion = this.props.devotion;
@@ -17,7 +31,7 @@ export default class DevotionsSingleScripture extends Component {
     // `data-status-scroll-container` is set in the react-swipe-views module
     return (
       <section
-        className="hard-sides hard-top background--light-primary"
+        className={this.getClasses()}
         data-status-scroll-item={true}
         data-status-scroll-offset={-50}
       >

--- a/sites/newspring/imports/pages/devotionals/index.jsx
+++ b/sites/newspring/imports/pages/devotionals/index.jsx
@@ -5,12 +5,12 @@ import { connect } from "react-apollo";
 import { VelocityComponent } from "velocity-react"
 import gql from "graphql-tag";
 
-import ReactPullToRefresh from "react-pull-to-refresh";
 import { Loading } from "apollos/dist/core/components"
 import { Headerable } from "apollos/dist/core/mixins"
 
 import { FeedItemSkeleton } from "apollos/dist/core/components/loading"
 import { nav as navActions } from "apollos/dist/core/store"
+import ApollosPullToRefresh from "apollos/dist/core/components/pullToRefresh";
 
 import Single from "./devotions.Single"
 
@@ -98,25 +98,15 @@ class Devotions extends Component {
         duration={1000}
         runOnMount={true}
       >
-        <div>
-
-          <div className="ptr-fake-background"></div>
-
-          <ReactPullToRefresh
-            onRefresh={this.handleRefresh}
-            icon={<i className="icon-leaf-outline"></i>}
-            loading={<i className="loading icon-leaf-outline"></i>}
-          >
-
-            <div className="background--light-primary">
-              <section className="soft-half">
-                <div className="grid">
-                  {this.renderItems()}
-                </div>
-              </section>
-            </div>
-          </ReactPullToRefresh>
-        </div>
+        <ApollosPullToRefresh handleRefresh={this.handleRefresh}>
+          <div className="background--light-primary">
+            <section className="soft-half">
+              <div className="grid">
+                {this.renderItems()}
+              </div>
+            </section>
+          </div>
+        </ApollosPullToRefresh>
       </VelocityComponent>
     )
   }

--- a/sites/newspring/imports/pages/discover/index.jsx
+++ b/sites/newspring/imports/pages/discover/index.jsx
@@ -1,6 +1,7 @@
 import { Component, PropTypes } from "react";
 import { connect } from "react-apollo";
 
+import liveActions from "apollos/dist/core/store/live"
 import Discover from "apollos/dist/core/blocks/discover";
 
 const mapStateToProps = (state) => ({ audio: state.audio });
@@ -12,6 +13,14 @@ class Template extends Component {
     return {
       paddingBottom: this.props.audio.state === "default" ? "20px" : "60px",
     }
+  }
+
+  componentWillMount() {
+    this.props.dispatch(liveActions.hide());
+  }
+
+  componentWillUnmount() {
+    this.props.dispatch(liveActions.show());
   }
 
   render() {

--- a/sites/newspring/imports/pages/home/index.jsx
+++ b/sites/newspring/imports/pages/home/index.jsx
@@ -4,7 +4,7 @@ import { VelocityComponent } from "velocity-react"
 import { connect } from "react-apollo";
 import gql from "graphql-tag";
 import { Link } from "react-router";
-import ReactPullToRefresh from "react-pull-to-refresh";
+import ApollosPullToRefresh from "apollos/dist/core/components/pullToRefresh";
 
 import Loading from "apollos/dist/core/components/loading"
 import { FeedItemSkeleton } from "apollos/dist/core/components/loading"
@@ -137,41 +137,33 @@ export default class Home extends Component {
     }
     return (
       <VelocityComponent
-          animation={"transition.fadeIn"}
-          duration={1000}
-          runOnMount={true}
-        >
-        <div>
-          <div className="ptr-fake-background"></div>
+        animation={"transition.fadeIn"}
+        duration={1000}
+        runOnMount={true}
+      >
+        <ApollosPullToRefresh handleRefresh={this.handleRefresh}>
+          <Split nav={true} classes={["background--light-primary"]}>
+            <Right
+              mobile={true}
+              background={photo}
+              classes={["floating--bottom", "text-left", "background--dark-primary"]}
+              ratioClasses={["floating__item", "overlay__item", "one-whole", "soft@lap-and-up", "floating--bottom", "text-left"]}
+              aspect="square"
+              link={heroLink}
+            >
 
-          <ReactPullToRefresh
-            onRefresh={this.handleRefresh}
-            icon={<i className="icon-leaf-outline"></i>}
-            loading={<i className="loading icon-leaf-outline"></i>}
-          >
-            <Split nav={true} classes={["background--light-primary"]}>
-              <Right
-                mobile={true}
-                background={photo}
-                classes={["floating--bottom", "text-left", "background--dark-primary"]}
-                ratioClasses={["floating__item", "overlay__item", "one-whole", "soft@lap-and-up", "floating--bottom", "text-left"]}
-                aspect="square"
-                link={heroLink}
-              >
+              <HomeHero item={heroItem ? heroItem : {}} />
 
-                <HomeHero item={heroItem ? heroItem : {}} />
-
-              </Right>
-            </Split>
-            <Left scroll={true} ref="container">
-              <section className="background--light-secondary soft-half@handheld soft@portable soft-double@anchored">
-                <div className="grid">
-                  {this.renderFeed()}
-                </div>
-              </section>
-            </Left>
-          </ReactPullToRefresh>
-        </div>
+            </Right>
+          </Split>
+          <Left scroll={true} ref="container">
+            <section className="background--light-secondary soft-half@handheld soft@portable soft-double@anchored">
+              <div className="grid">
+                {this.renderFeed()}
+              </div>
+            </section>
+          </Left>
+        </ApollosPullToRefresh>
       </VelocityComponent>
 
     )

--- a/sites/newspring/imports/pages/index.js
+++ b/sites/newspring/imports/pages/index.js
@@ -10,6 +10,7 @@ if (process.env.NATIVE) {
   import Series from "./series/index"
   import Stories from "./stories/index"
   import Sections from "./sections/index";
+  import Video from "./video/index";
 }
 
 
@@ -28,6 +29,7 @@ if (process.env.NATIVE) {
     Stories.Routes,
     Sections.Routes,
     Discover.Routes,
+    Video.Routes,
   );
 }
 

--- a/sites/newspring/imports/pages/music/index.jsx
+++ b/sites/newspring/imports/pages/music/index.jsx
@@ -5,12 +5,12 @@ import { connect } from "react-apollo";
 import { VelocityComponent } from "velocity-react"
 import gql from "graphql-tag";
 
-import ReactPullToRefresh from "react-pull-to-refresh";
 import { Loading } from "apollos/dist/core/components"
 import { Headerable } from "apollos/dist/core/mixins"
 
 import { FeedItemSkeleton } from "apollos/dist/core/components/loading"
 import { nav as navActions } from "apollos/dist/core/store"
+import ApollosPullToRefresh from "apollos/dist/core/components/pullToRefresh";
 
 import Album from "./music.Album"
 
@@ -108,22 +108,15 @@ class Template extends Component {
         duration={1000}
         runOnMount={true}
       >
-        <div>
-          <div className="ptr-fake-background"></div>
-          <ReactPullToRefresh
-            onRefresh={this.handleRefresh}
-            icon={<i className="icon-leaf-outline"></i>}
-            loading={<i className="loading icon-leaf-outline"></i>}
-          >
-            <div className="background--light-primary">
-              <section className="soft-half">
-                <div className="grid">
-                  {this.renderItems()}
-                </div>
-              </section>
-            </div>
-          </ReactPullToRefresh>
-        </div>
+        <ApollosPullToRefresh handleRefresh={this.handleRefresh}>
+          <div className="background--light-primary">
+            <section className="soft-half">
+              <div className="grid">
+                {this.renderItems()}
+              </div>
+            </section>
+          </div>
+        </ApollosPullToRefresh>
       </VelocityComponent>
     );
   }

--- a/sites/newspring/imports/pages/series/index.jsx
+++ b/sites/newspring/imports/pages/series/index.jsx
@@ -5,12 +5,12 @@ import { connect } from "react-apollo";
 import { VelocityComponent } from "velocity-react"
 import gql from "graphql-tag";
 
-import ReactPullToRefresh from "react-pull-to-refresh";
 import { Loading } from "apollos/dist/core/components"
 import { Headerable } from "apollos/dist/core/mixins"
 
 import { FeedItemSkeleton } from "apollos/dist/core/components/loading"
 import { nav as navActions } from "apollos/dist/core/store"
+import ApollosPullToRefresh from "apollos/dist/core/components/pullToRefresh";
 
 import Single from "./series.Single"
 import SingleVideo from "./series.SingleVideo"
@@ -103,24 +103,15 @@ class Template extends Component {
         duration={1000}
         runOnMount={true}
       >
-        <div>
-          <div className="ptr-fake-background"></div>
-
-          <ReactPullToRefresh
-            onRefresh={this.handleRefresh}
-            icon={<i className="icon-leaf-outline"></i>}
-            loading={<i className="loading icon-leaf-outline"></i>}
-          >
-
-            <div className="background--light-primary">
-              <section className="soft-half">
-                <div className="grid">
-                  {this.renderItems()}
-                </div>
-              </section>
-            </div>
-          </ReactPullToRefresh>
-        </div>
+        <ApollosPullToRefresh handleRefresh={this.handleRefresh}>
+          <div className="background--light-primary">
+            <section className="soft-half">
+              <div className="grid">
+                {this.renderItems()}
+              </div>
+            </section>
+          </div>
+        </ApollosPullToRefresh>
       </VelocityComponent>
     );
   }

--- a/sites/newspring/imports/pages/series/series.Single.jsx
+++ b/sites/newspring/imports/pages/series/series.Single.jsx
@@ -70,6 +70,9 @@ export default class SeriesSingle extends Component {
   componentWillMount() {
     if (process.env.WEB) return;
 
+    // needed for cached data
+    this.handleHeaderStyle(this.props);
+
     this.props.dispatch(navActions.setLevel("CONTENT"));
     this.props.dispatch(navActions.setAction("CONTENT", {
       id: 2,
@@ -78,6 +81,10 @@ export default class SeriesSingle extends Component {
   }
 
   componentWillUpdate(nextProps) {
+    this.handleHeaderStyle(nextProps);
+  }
+
+  handleHeaderStyle = (nextProps) => {
     const { content } = nextProps.series;
     if(!content) return;
 

--- a/sites/newspring/imports/pages/series/series.SingleVideo.jsx
+++ b/sites/newspring/imports/pages/series/series.SingleVideo.jsx
@@ -89,7 +89,7 @@ const mapQueriesToProps = ({ ownProps, state }) => ({
   //   query: gql`query IsLive {
   //     live {
   //       live
-  //       streamUrl
+  //       embedCode
   //     }
   //   }`,
   //   forceFetch: false,

--- a/sites/newspring/imports/pages/series/series.SingleVideo.jsx
+++ b/sites/newspring/imports/pages/series/series.SingleVideo.jsx
@@ -85,18 +85,11 @@ const mapQueriesToProps = ({ ownProps, state }) => ({
     forceFetch: false,
     returnPartialData: false,
   },
-  // live: {
-  //   query: gql`query IsLive {
-  //     live {
-  //       live
-  //       embedCode
-  //     }
-  //   }`,
-  //   forceFetch: false,
-  //   returnPartialData: false,
-  // },
 });
-@connect({ mapQueriesToProps })
+
+const mapStateToProps = (state) => ({ live: state.live });
+
+@connect({ mapQueriesToProps, mapStateToProps })
 @ReactMixin.decorate(Likeable)
 @ReactMixin.decorate(Shareable)
 @ReactMixin.decorate(Headerable)
@@ -117,8 +110,7 @@ export default class SeriesSingleVideo extends Component {
 
     const color = Helpers.collections.color(content);
 
-    // const { live } = this.props.live;
-    const live = true;
+    const { live } = this.props.live;
 
     const options = {
       title: "Series",

--- a/sites/newspring/imports/pages/series/series.SingleVideo.jsx
+++ b/sites/newspring/imports/pages/series/series.SingleVideo.jsx
@@ -85,6 +85,16 @@ const mapQueriesToProps = ({ ownProps, state }) => ({
     forceFetch: false,
     returnPartialData: false,
   },
+  // live: {
+  //   query: gql`query IsLive {
+  //     live {
+  //       live
+  //       streamUrl
+  //     }
+  //   }`,
+  //   forceFetch: false,
+  //   returnPartialData: false,
+  // },
 });
 @connect({ mapQueriesToProps })
 @ReactMixin.decorate(Likeable)
@@ -107,11 +117,18 @@ export default class SeriesSingleVideo extends Component {
 
     const color = Helpers.collections.color(content);
 
-    this.props.dispatch(headerActions.set({
+    // const { live } = this.props.live;
+    const live = true;
+
+    const options = {
       title: "Series",
-      subTitle: content.title,
-      color: color
-    }));
+      color: color,
+    };
+
+    if (!live) options.subTitle = content.title;
+
+    this.props.dispatch(headerActions.set(options));
+
   }
 
   render() {

--- a/sites/newspring/imports/pages/stories/index.jsx
+++ b/sites/newspring/imports/pages/stories/index.jsx
@@ -5,9 +5,9 @@ import { connect } from "react-apollo";
 import { VelocityComponent } from "velocity-react"
 import gql from "graphql-tag";
 
-import ReactPullToRefresh from "react-pull-to-refresh";
 import { Loading } from "apollos/dist/core/components"
 import { Headerable } from "apollos/dist/core/mixins"
+import ApollosPullToRefresh from "apollos/dist/core/components/pullToRefresh";
 
 import { FeedItemSkeleton } from "apollos/dist/core/components/loading"
 import { nav as navActions } from "apollos/dist/core/store"
@@ -104,22 +104,15 @@ class Template extends Component {
         duration={1000}
         runOnMount={true}
       >
-        <div>
-          <div className="ptr-fake-background"></div>
-          <ReactPullToRefresh
-            onRefresh={this.handleRefresh}
-            icon={<i className="icon-leaf-outline"></i>}
-            loading={<i className="loading icon-leaf-outline"></i>}
-          >
-            <div className="background--light-primary">
-              <section className="soft-half">
-                <div className="grid">
-                  {this.renderItems()}
-                </div>
-              </section>
-            </div>
-          </ReactPullToRefresh>
-        </div>
+        <ApollosPullToRefresh handleRefresh={this.handleRefresh}>
+          <div className="background--light-primary">
+            <section className="soft-half">
+              <div className="grid">
+                {this.renderItems()}
+              </div>
+            </section>
+          </div>
+          </ApollosPullToRefresh>
       </VelocityComponent>
     );
   }

--- a/sites/newspring/imports/pages/video/index.jsx
+++ b/sites/newspring/imports/pages/video/index.jsx
@@ -14,8 +14,6 @@ class Template extends Component {
 
   render() {
     let { embedCode } = this.props.params;
-    // XXX for testing hardcode embed code
-    embedCode = "M1anI0ZDqWIIFq5VESbHl7Hok1zz0N83";
 
     return (
       <div className="locked-ends locked-sides background--dark-primary floating">

--- a/sites/newspring/imports/pages/video/index.jsx
+++ b/sites/newspring/imports/pages/video/index.jsx
@@ -4,12 +4,16 @@ import { connect } from "react-redux";
 import { Video } from "/imports/components/players"
 
 import navActions from "apollos/dist/core/store/nav";
+import headerActions from "apollos/dist/core/store/header"
 
 @connect()
 class Template extends Component {
 
   componentWillMount() {
     this.props.dispatch(navActions.setLevel("BASIC_CONTENT"));
+    this.props.dispatch(headerActions.set({
+      title: "Live Now",
+    }));
   }
 
   render() {

--- a/sites/newspring/imports/pages/video/index.jsx
+++ b/sites/newspring/imports/pages/video/index.jsx
@@ -1,0 +1,39 @@
+import { Component, PropTypes } from "react";
+import { connect } from "react-redux";
+
+import { Video } from "/imports/components/players"
+
+import navActions from "apollos/dist/core/store/nav";
+
+@connect()
+class Template extends Component {
+
+  componentWillMount() {
+    this.props.dispatch(navActions.setLevel("BASIC_CONTENT"));
+  }
+
+  render() {
+    let { embedCode } = this.props.params;
+    // XXX for testing hardcode embed code
+    embedCode = "M1anI0ZDqWIIFq5VESbHl7Hok1zz0N83";
+
+    return (
+      <div className="locked-ends locked-sides background--dark-primary floating">
+        <div className="floating__item one-whole">
+          <Video id={embedCode} ref="video"/>
+        </div>
+      </div>
+    );
+  }
+}
+
+const Routes = [
+  {
+    path: "/video/:embedCode",
+    component: Template,
+  },
+];
+
+export default {
+  Routes,
+};

--- a/sites/newspring/mobile-config.js
+++ b/sites/newspring/mobile-config.js
@@ -6,7 +6,7 @@ App.info({
   email: 'web@newspring.cc',
   website: 'https://newspring.cc',
   version: '0.0.3',
-  buildNumber: '88'
+  buildNumber: '89'
 });
 
 App.icons({

--- a/sites/newspring/mobile-config.js
+++ b/sites/newspring/mobile-config.js
@@ -6,7 +6,7 @@ App.info({
   email: 'web@newspring.cc',
   website: 'https://newspring.cc',
   version: '0.0.3',
-  buildNumber: '84'
+  buildNumber: '85'
 });
 
 App.icons({

--- a/sites/newspring/mobile-config.js
+++ b/sites/newspring/mobile-config.js
@@ -6,7 +6,7 @@ App.info({
   email: 'web@newspring.cc',
   website: 'https://newspring.cc',
   version: '0.0.3',
-  buildNumber: '87'
+  buildNumber: '88'
 });
 
 App.icons({

--- a/sites/newspring/mobile-config.js
+++ b/sites/newspring/mobile-config.js
@@ -6,7 +6,7 @@ App.info({
   email: 'web@newspring.cc',
   website: 'https://newspring.cc',
   version: '0.0.3',
-  buildNumber: '85'
+  buildNumber: '86'
 });
 
 App.icons({

--- a/sites/newspring/mobile-config.js
+++ b/sites/newspring/mobile-config.js
@@ -6,7 +6,7 @@ App.info({
   email: 'web@newspring.cc',
   website: 'https://newspring.cc',
   version: '0.0.3',
-  buildNumber: '83'
+  buildNumber: '84'
 });
 
 App.icons({

--- a/sites/newspring/mobile-config.js
+++ b/sites/newspring/mobile-config.js
@@ -6,7 +6,7 @@ App.info({
   email: 'web@newspring.cc',
   website: 'https://newspring.cc',
   version: '0.0.3',
-  buildNumber: '81'
+  buildNumber: '82'
 });
 
 App.icons({

--- a/sites/newspring/mobile-config.js
+++ b/sites/newspring/mobile-config.js
@@ -6,7 +6,7 @@ App.info({
   email: 'web@newspring.cc',
   website: 'https://newspring.cc',
   version: '0.0.3',
-  buildNumber: '86'
+  buildNumber: '87'
 });
 
 App.icons({

--- a/sites/newspring/mobile-config.js
+++ b/sites/newspring/mobile-config.js
@@ -6,7 +6,7 @@ App.info({
   email: 'web@newspring.cc',
   website: 'https://newspring.cc',
   version: '0.0.3',
-  buildNumber: '82'
+  buildNumber: '83'
 });
 
 App.icons({

--- a/sites/newspring/stylesheets/vendor/_swipe.scss
+++ b/sites/newspring/stylesheets/vendor/_swipe.scss
@@ -5,7 +5,7 @@
   flex-flow: column nowrap;
   overflow: hidden;
   position: absolute;
-  padding-bottom: 60px;
+  padding-bottom: 50px;
   -webkit-overflow-scrolling: touch;
   background-color: #FFF;
 }


### PR DESCRIPTION
ThisThis will bring the ability to watch the live feed to the app.

## Basic UI implementation

Currently, the live bar always shows. There are several places where I have commented out the actual check, and replaced with `if(true)`. Also there are places where I have commented out the query entirely. But, the polling is there in the Live component. And now that we have the live endpoint on heighliner, we should be able to do the below:

- [x] build UI
- [x] handle sermon case
- [x] handle devo case
- [x] handle case when devo has no scripture (@johnthepink)
- [x] handle discover case
- [x] add animation on render of live bar
- [x] handle pull to refresh when live bar active (@benwiley)
- [x] add css animation for background of live bar (@samclaridge)
- [x] adjust and test with real endpoint (@johnthepink)

## Real implementation

![unspecified](https://cloud.githubusercontent.com/assets/816517/16781455/6815f9d2-4849-11e6-8029-56a826cf8491.png)

Our goal is to render the sermon component when clicking the live bar. So, we will need to adjust some things to handle this. We will either need to update the live query to include current series, and current sermon information, or make separate queries for that information.

## Update

Based on conversation, we are rolling with a more flexible live player page that just contains the video. So, I've removed the check boxes for "Real Implementation", and instead we need to:

- [x] make live stream work on iOS
- [x] make live stream work on Android
- [x] refactor live redux store