### PR TITLE
use id when generating links if no entryId

### DIFF
--- a/sites/newspring/imports/helpers/content/content.links.js
+++ b/sites/newspring/imports/helpers/content/content.links.js
@@ -1,6 +1,6 @@
 
 function contentLink(contentItem) {
-  const entryId = contentItem.entryId;
+  const entryId = contentItem.entryId || contentItem.id;
   const category = contentItem.channelName;
 
   switch(category) {


### PR DESCRIPTION
@jbaxleyiii this is where the problem is, and this seems to fix it, but is this the best way? It seemed like some things still had entry id's, while others were just using an id. Maybe I'm wrong. 

We will need to clear people's likes, or run a migration to update all of the entries in mongo. Probably not necessary since this is a beta, but something to think about in the future.