### PR TITLE
iPad Music Player Nav

### DIFF
--- a/sites/newspring/client/startup.js
+++ b/sites/newspring/client/startup.js
@@ -154,6 +154,9 @@ if (process.env.NATIVE) {
 Meteor.startup(() => {
   if (Meteor.isClient) {
 
+    window.isPhone = window.outerWidth < 768;
+    window.isTablet = window.outerWidth >= 768;
+
     (function(kitID) {
       if (!kitID) {
         return

--- a/sites/newspring/imports/components/players/audio/index.jsx
+++ b/sites/newspring/imports/components/players/audio/index.jsx
@@ -56,11 +56,15 @@ export default class AudioPlayer extends Component {
 
     const triggerModal = () => {
       this.props.dispatch(modal.render(FullPlayer, { coverHeader: true, audioPlayer: true }));
-      this.props.dispatch(navActions.setLevel("DOWN"));
-      const { isLight } = this.props.audio.playing.album.content;
-      // reverse is light so it makes sense for foreground
-      const fgColor = isLight ? "light" : "dark";
-      this.props.dispatch(navActions.setColor("transparent", fgColor));
+
+      // if phone, change to down arrow and make nav transparent
+      if (window.isPhone) {
+        this.props.dispatch(navActions.setLevel("DOWN"));
+        const { isLight } = this.props.audio.playing.album.content;
+        // reverse is light so it makes sense for foreground
+        const fgColor = isLight ? "light" : "dark";
+        this.props.dispatch(navActions.setColor("transparent", fgColor));
+      }
     };
 
     if( expanding ) {


### PR DESCRIPTION
- keeps modal nav normal when triggering FullPlayer on iPad
- adds `window.isPhone` and `window.isTablet` to make distinguishing the two easy during this process

@samclaridge @jbaxleyiii what else do we need to do here?

<img width="557" alt="screenshot 2016-09-01 20 33 36" src="https://cloud.githubusercontent.com/assets/816517/18189066/4826a6ee-7085-11e6-8e29-6013e18b87ee.png">
