### PR TITLE
Mini Player iPad

### DIFF
--- a/sites/newspring/imports/components/players/audio/audio.styles.miniPlayer.js
+++ b/sites/newspring/imports/components/players/audio/audio.styles.miniPlayer.js
@@ -8,7 +8,12 @@ export default StyleSheet.create({
     zIndex: "101",
     // account for border on light version of nav
     // marginBottom: "52px",
-    marginBottom: "50px",
+    "@media (max-width: 767px)": {
+      marginBottom: "50px",
+    },
+    "@media (min-width: 768px)": {
+      paddingLeft: "90px",
+    },
   },
 
   "mini-album-cover": {


### PR DESCRIPTION
This fits the mini player to the bottom and moves it left to account for the left nav.

<img width="569" alt="screenshot 2016-09-01 21 18 51" src="https://cloud.githubusercontent.com/assets/816517/18189559/fc994df8-7089-11e6-8e13-4b6222fb37ce.png">
