### PR TITLE
fix issue with ooyala player control bar height

### DIFF
--- a/sites/newspring/public/ooyala/skin.new.json
+++ b/sites/newspring/public/ooyala/skin.new.json
@@ -158,7 +158,6 @@
       }
     },
     "autoHide": true,
-    "height": 60,
     "logo": {
       "imageResource": {"url": "//ns-ops.s3.amazonaws.com/player/ns.logo.white.png","androidResource" : "logo","iosResource" : "logo"},
       "clickUrl": "https://newspring.cc",


### PR DESCRIPTION
the control bar (play button, volume, etc) of the ooyala player was being overridden to the mobile size, instead of using the responsiveness of the stylesheet.