### PR TITLE
Hot reload on resume

### DIFF
--- a/sites/newspring/.meteor/packages
+++ b/sites/newspring/.meteor/packages
@@ -33,3 +33,4 @@ meteorhacks:fast-render@2.12.0
 # nathantreid:css-modules
 crosswalk@1.6.2
 shell-server
+dispatch:reload-on-resume

--- a/sites/newspring/.meteor/versions
+++ b/sites/newspring/.meteor/versions
@@ -25,6 +25,7 @@ ddp-rate-limiter@1.0.5
 ddp-server@1.3.10
 deps@1.0.12
 diff-sequence@1.0.6
+dispatch:reload-on-resume@0.0.2
 ecmascript@0.5.8
 ecmascript-runtime@0.3.14
 ejson@1.0.12

--- a/sites/newspring/mobile-config.js
+++ b/sites/newspring/mobile-config.js
@@ -6,7 +6,7 @@ App.info({
   email: 'web@newspring.cc',
   website: 'https://newspring.cc',
   version: '0.0.3',
-  buildNumber: '138'
+  buildNumber: '139'
 });
 
 App.icons({


### PR DESCRIPTION
This fixes that crazy flash after install by preventing reload on a hot code push until the user leaves and then resumes the app. During the reload, the app's splash screen is shown. So it feels totally normal.