### PR TITLE
really bad POC for dynamic stylesheets

### DIFF
--- a/src/@modules/Header/index.js
+++ b/src/@modules/Header/index.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 
 import createStyleSheet from '@primitives/stylesheet';
 
-const getStyles = createStyleSheet(({ primaryColor }) => ({
+const styles = createStyleSheet(({ primaryColor }) => ({
   container: {
     height: 60,
     backgroundColor: primaryColor,
@@ -30,8 +30,8 @@ export default class Header extends PureComponent {
 
   render() {
     return (
-      <View style={getStyles().container}>
-        <Text style={getStyles().text}>{this.props.titleText}</Text>
+      <View style={styles.container}>
+        <Text style={styles.text}>{this.props.titleText}</Text>
       </View>
     );
   }

--- a/src/@modules/Header/index.js
+++ b/src/@modules/Header/index.js
@@ -1,22 +1,23 @@
 import React, { PureComponent } from 'react';
 import {
-  StyleSheet,
   Text,
   View,
 } from 'react-native';
 import PropTypes from 'prop-types';
 
-const styles = StyleSheet.create({
+import createStyleSheet from '@primitives/stylesheet';
+
+const getStyles = createStyleSheet(({ primaryColor }) => ({
   container: {
     height: 60,
-    backgroundColor: 'green',
+    backgroundColor: primaryColor,
     alignItems: 'center',
     justifyContent: 'center',
   },
   text: {
     color: 'white',
   },
-});
+}));
 
 export default class Header extends PureComponent {
   static propTypes = {
@@ -29,8 +30,8 @@ export default class Header extends PureComponent {
 
   render() {
     return (
-      <View style={styles.container}>
-        <Text style={styles.text}>{this.props.titleText}</Text>
+      <View style={getStyles().container}>
+        <Text style={getStyles().text}>{this.props.titleText}</Text>
       </View>
     );
   }

--- a/src/@primitives/stylesheet.js
+++ b/src/@primitives/stylesheet.js
@@ -7,10 +7,10 @@ const styleSheetRegistry = [];
 const createStyleSheet = (getter) => {
   const reference = {
     getter,
-    value: null,
+    value: { },
   };
   styleSheetRegistry.push(reference);
-  return () => reference.value;
+  return reference.value;
 };
 
 export const StyleSheetsProvider = compose(
@@ -18,7 +18,7 @@ export const StyleSheetsProvider = compose(
   onlyUpdateForKeys(['theme', 'children']),
 )(({ children, theme }) => {
   styleSheetRegistry.forEach((reference) => {
-    reference.value = StyleSheet.create(reference.getter(theme));
+    Object.assign(reference.value, StyleSheet.create(reference.getter(theme)));
   });
   return children || null;
 });

--- a/src/@primitives/stylesheet.js
+++ b/src/@primitives/stylesheet.js
@@ -1,0 +1,26 @@
+import { StyleSheet } from 'react-native';
+import { compose, onlyUpdateForKeys } from 'recompose';
+import withTheme from '@primitives/withTheme';
+
+const styleSheetRegistry = [];
+
+const createStyleSheet = (getter) => {
+  const reference = {
+    getter,
+    value: null,
+  };
+  styleSheetRegistry.push(reference);
+  return () => reference.value;
+};
+
+export const StyleSheetsProvider = compose(
+  withTheme(),
+  onlyUpdateForKeys(['theme', 'children']),
+)(({ children, theme }) => {
+  styleSheetRegistry.forEach((reference) => {
+    reference.value = StyleSheet.create(reference.getter(theme));
+  });
+  return children || null;
+});
+
+export default createStyleSheet;

--- a/src/@primitives/withTheme.js
+++ b/src/@primitives/withTheme.js
@@ -3,7 +3,7 @@ import getContext from 'recompose/getContext';
 import compose from 'recompose/compose';
 import mapProps from 'recompose/mapProps';
 
-const DEFAULT_MAPPER_FN = ({ theme, ...otherProps } = {}) => ({ ...theme, ...otherProps });
+const DEFAULT_MAPPER_FN = ({ theme, ...otherProps } = {}) => ({ theme, ...otherProps });
 
 export default function (mapperFn = DEFAULT_MAPPER_FN) {
   return compose(

--- a/src/index.js
+++ b/src/index.js
@@ -13,19 +13,23 @@ import FontLoader from '@primitives/FontLoader';
 import Store from '@data/Store';
 import Client from '@data/Client';
 
+import { StyleSheetsProvider } from '@primitives/stylesheet';
+
 const App = () => (
   <ApolloProvider client={Client}>
     <ReduxProvider store={Store}>
       <ThemeProvider>
-        <FontLoader>
-          <Router>
-            <View style={{ flex: 1 }}>
-              {Platform.OS === 'android' ? <AndroidBackButton /> : null}
-              <Route exact path="/" component={pages.Feed} />
-              <Route exact path="/sections" component={pages.Sections} />
-            </View>
-          </Router>
-        </FontLoader>
+        <StyleSheetsProvider>
+          <FontLoader>
+            <Router>
+              <View style={{ flex: 1 }}>
+                {Platform.OS === 'android' ? <AndroidBackButton /> : null}
+                <Route exact path="/" component={pages.Feed} />
+                <Route exact path="/sections" component={pages.Sections} />
+              </View>
+            </Router>
+          </FontLoader>
+        </StyleSheetsProvider>
       </ThemeProvider>
     </ReduxProvider>
   </ApolloProvider>


### PR DESCRIPTION
Had this idea for doing dynamic stylesheets (ability to use theme vars inside of StyleSheet).

Need to think about this some more. The code in this PR is bad...but just a proof of concept.

Essentially: When you create a stylesheet, store a reference to that stylesheet in a central store, and return an object. After `theme` is loaded, generate all of the stylesheets by looping through the stylesheet registry and modifying the original object that was returned.

I feel like this _could_ be negligible from a performance standpoint... `StyleSheet.create` is going to be called for _every_ stylesheet on mount of our application either way. This is just delaying running `StyleSheet.create` until after the theme is loaded. But... yeah.

Fixes [issue-number]

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

