### PR TITLE
Style out <Header> component

### DIFF
--- a/src/@modules/Header/Header.stories.js
+++ b/src/@modules/Header/Header.stories.js
@@ -2,8 +2,13 @@ import React from 'react';
 
 import { storiesOf } from '@storybook/react-native';
 
+import ThemeProvider from '@primitives/ThemeProvider';
 import Header from '@modules/Header';
 
 storiesOf('Header', module)
-  .add('renders', () => <Header />);
+  .add('renders', () => (
+    <ThemeProvider>
+      <Header titleText="Welcome!" />
+    </ThemeProvider>
+  ));
 

--- a/src/@modules/Header/Header.tests.js
+++ b/src/@modules/Header/Header.tests.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import ThemeProvider from '@primitives/ThemeProvider';
+
 import Header from './';
 
 describe('The Header component', () => {
   it('should render correctly', () => {
     const tree = renderer.create(
-      <Header />,
+      <ThemeProvider>
+        <Header />
+      </ThemeProvider>,
     );
     expect(tree).toMatchSnapshot();
   });

--- a/src/@modules/Header/Header.tests.js
+++ b/src/@modules/Header/Header.tests.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import Component from './';
+import Header from './';
 
-it('renders correctly', () => {
-  const tree = renderer.create(
-    <Component />,
-  );
-  expect(tree).toMatchSnapshot();
+describe('The Header component', () => {
+  it('should render correctly', () => {
+    const tree = renderer.create(
+      <Header />,
+    );
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/src/@modules/Header/__snapshots__/Header.tests.js.snap
+++ b/src/@modules/Header/__snapshots__/Header.tests.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
+exports[`The Header component should render correctly 1`] = `
 <View
   onLayout={[Function]}
   style={

--- a/src/@modules/Header/__snapshots__/Header.tests.js.snap
+++ b/src/@modules/Header/__snapshots__/Header.tests.js.snap
@@ -2,27 +2,41 @@
 
 exports[`renders correctly 1`] = `
 <View
+  onLayout={[Function]}
   style={
-    Object {
-      "alignItems": "center",
-      "backgroundColor": "green",
-      "height": 60,
-      "justifyContent": "center",
-    }
+    Array [
+      Object {
+        "backgroundColor": undefined,
+      },
+      Object {
+        "paddingBottom": 0,
+        "paddingLeft": 0,
+        "paddingRight": 0,
+        "paddingTop": 20,
+      },
+    ]
   }
 >
-  <Text
-    accessible={true}
-    allowFontScaling={true}
-    disabled={false}
-    ellipsizeMode="tail"
+  <View
     style={
       Object {
-        "color": "white",
+        "alignItems": "center",
+        "height": 50,
+        "justifyContent": "center",
       }
     }
   >
-    
-  </Text>
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+      style={
+        Object {
+          "color": "white",
+        }
+      }
+    />
+  </View>
 </View>
 `;

--- a/src/@modules/Header/__snapshots__/Header.tests.js.snap
+++ b/src/@modules/Header/__snapshots__/Header.tests.js.snap
@@ -6,7 +6,7 @@ exports[`The Header component should render correctly 1`] = `
   style={
     Array [
       Object {
-        "backgroundColor": undefined,
+        "backgroundColor": "#6bac43",
       },
       Object {
         "paddingBottom": 0,

--- a/src/@modules/Header/index.js
+++ b/src/@modules/Header/index.js
@@ -1,37 +1,36 @@
-import React, { PureComponent } from 'react';
-import {
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
+import React from 'react';
+import { Text, View, StatusBar, Platform } from 'react-native';
 import PropTypes from 'prop-types';
+import { compose, setPropTypes, branch, renderNothing } from 'recompose';
+import SafeAreaView from '@primitives/SafeAreaView';
+import withTheme from '@primitives/withTheme';
+import styled from '@primitives/styled';
 
-const styles = StyleSheet.create({
-  container: {
-    height: 60,
-    backgroundColor: 'green',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  text: {
-    color: 'white',
-  },
-});
+const StyledHeaderBar = styled({
+  height: 50,
+  alignItems: 'center',
+  justifyContent: 'center',
+})(View);
 
-export default class Header extends PureComponent {
-  static propTypes = {
+const StyledHeaderText = styled({
+  color: 'white',
+})(Text); // todo: use a different Text component that brings in correct styles
+
+const enhance = compose(
+  branch(() => Platform.OS === 'web', renderNothing), // Header isn't a supported component on web
+  withTheme(({ theme: { primaryColor } = {} }) => ({ primaryColor })),
+  setPropTypes({
     titleText: PropTypes.string,
-  };
+  }),
+);
 
-  static defaultProps = {
-    titleText: '',
-  };
+const Header = enhance(({ titleText, primaryColor }) => (
+  <SafeAreaView style={{ backgroundColor: primaryColor }}>
+    <StatusBar barStyle="light-content" />
+    <StyledHeaderBar>
+      <StyledHeaderText>{titleText}</StyledHeaderText>
+    </StyledHeaderBar>
+  </SafeAreaView>
+));
 
-  render() {
-    return (
-      <View style={styles.container}>
-        <Text style={styles.text}>{this.props.titleText}</Text>
-      </View>
-    );
-  }
-}
+export default Header;

--- a/src/@modules/Header/index.js
+++ b/src/@modules/Header/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Text, View, StatusBar, Platform } from 'react-native';
 import PropTypes from 'prop-types';
-import { compose, setPropTypes, branch, renderNothing } from 'recompose';
+import { compose, setPropTypes, branch, renderNothing, pure } from 'recompose';
 import SafeAreaView from '@primitives/SafeAreaView';
 import withTheme from '@primitives/withTheme';
 import styled from '@primitives/styled';
@@ -17,6 +17,7 @@ const StyledHeaderText = styled({
 })(Text); // todo: use a different Text component that brings in correct styles
 
 const enhance = compose(
+  pure,
   branch(() => Platform.OS === 'web', renderNothing), // Header isn't a supported component on web
   withTheme(({ theme: { primaryColor } = {} }) => ({ primaryColor })),
   setPropTypes({
@@ -24,13 +25,16 @@ const enhance = compose(
   }),
 );
 
-const Header = enhance(({ titleText, primaryColor }) => (
-  <SafeAreaView style={{ backgroundColor: primaryColor }}>
-    <StatusBar barStyle="light-content" />
-    <StyledHeaderBar>
-      <StyledHeaderText>{titleText}</StyledHeaderText>
-    </StyledHeaderBar>
-  </SafeAreaView>
-));
+const Header = enhance(({ titleText, primaryColor }) => {
+  const dynamicBackground = { backgroundColor: primaryColor };
+  return (
+    <SafeAreaView style={dynamicBackground}>
+      <StatusBar barStyle="light-content" />
+      <StyledHeaderBar>
+        <StyledHeaderText>{titleText}</StyledHeaderText>
+      </StyledHeaderBar>
+    </SafeAreaView>
+  );
+});
 
 export default Header;


### PR DESCRIPTION
Fixes #39 

TODO: Purposefully not styling the <Text> anymore then text color, as I'm hoping we can swap out the real text component with whatever @burkeshartsis is building.

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

