### PR TITLE
Feed card fixes

### DIFF
--- a/src/@ui/CardWrapper/CardWrapper.stories.js
+++ b/src/@ui/CardWrapper/CardWrapper.stories.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react-native';
 
 import CardWrapper from './';
 
-storiesOf('@primitives/CardWrapper', module)
+storiesOf('@ui/CardWrapper', module)
   .add('Default', () => {
     const centered = {
       justifyContent: 'center',
@@ -21,6 +21,27 @@ storiesOf('@primitives/CardWrapper', module)
     return (
       <View style={centered}>
         <CardWrapper style={cardDimensions}>
+          <Text>Boom!</Text>
+        </CardWrapper>
+      </View>
+    );
+  })
+  .add('With backgroundColor', () => {
+    const centered = {
+      justifyContent: 'center',
+      alignItems: 'center',
+      flex: 1,
+      backgroundColor: '#f7f7f7',
+    };
+
+    const cardDimensions = {
+      height: 400,
+      width: '92%',
+    };
+
+    return (
+      <View style={centered}>
+        <CardWrapper style={cardDimensions} backgroundColor={'salmon'}>
           <Text>Boom!</Text>
         </CardWrapper>
       </View>

--- a/src/@ui/CardWrapper/CardWrapper.tests.js
+++ b/src/@ui/CardWrapper/CardWrapper.tests.js
@@ -23,6 +23,16 @@ describe('the Card component', () => {
     );
     expect(tree).toMatchSnapshot();
   });
+  it('should accept a backgroundColor', () => {
+    const tree = renderer.create(
+      <ThemeProvider>
+        <CardWrapper backgroundColor={'salmon'}>
+          <Text>Boom!</Text>
+        </CardWrapper>
+      </ThemeProvider>,
+    );
+    expect(tree).toMatchSnapshot();
+  });
   it('should accept and render passed in styles', () => {
     const cardDimensions = {
       height: 400,

--- a/src/@ui/CardWrapper/__snapshots__/CardWrapper.tests.js.snap
+++ b/src/@ui/CardWrapper/__snapshots__/CardWrapper.tests.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`the Card component should accept additional props 1`] = `
+exports[`the Card component should accept a backgroundColor 1`] = `
 <View
-  accessible={false}
+  cardColor="salmon"
   style={
     Object {
-      "backgroundColor": "#fff",
+      "backgroundColor": "salmon",
       "borderRadius": 6,
       "shadowColor": "#dddddd",
       "shadowOffset": Object {
@@ -14,6 +14,47 @@ exports[`the Card component should accept additional props 1`] = `
       },
       "shadowOpacity": 1,
       "shadowRadius": 3,
+      "width": "100%",
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "borderRadius": 6,
+        "flex": 1,
+        "overflow": "hidden",
+      }
+    }
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      disabled={false}
+      ellipsizeMode="tail"
+    >
+      Boom!
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`the Card component should accept additional props 1`] = `
+<View
+  accessible={false}
+  cardColor={undefined}
+  style={
+    Object {
+      "backgroundColor": "#ffffff",
+      "borderRadius": 6,
+      "shadowColor": "#dddddd",
+      "shadowOffset": Object {
+        "height": 1,
+        "width": 0,
+      },
+      "shadowOpacity": 1,
+      "shadowRadius": 3,
+      "width": "100%",
     }
   }
 >
@@ -31,9 +72,10 @@ exports[`the Card component should accept additional props 1`] = `
 
 exports[`the Card component should accept and render passed in styles 1`] = `
 <View
+  cardColor={undefined}
   style={
     Object {
-      "backgroundColor": "#fff",
+      "backgroundColor": "#ffffff",
       "borderRadius": 6,
       "height": 400,
       "shadowColor": "#dddddd",
@@ -61,9 +103,10 @@ exports[`the Card component should accept and render passed in styles 1`] = `
 
 exports[`the Card component should render 1`] = `
 <View
+  cardColor={undefined}
   style={
     Object {
-      "backgroundColor": "#fff",
+      "backgroundColor": "#ffffff",
       "borderRadius": 6,
       "shadowColor": "#dddddd",
       "shadowOffset": Object {
@@ -72,6 +115,7 @@ exports[`the Card component should render 1`] = `
       },
       "shadowOpacity": 1,
       "shadowRadius": 3,
+      "width": "100%",
     }
   }
 >
@@ -89,9 +133,10 @@ exports[`the Card component should render 1`] = `
 
 exports[`the Card component should render children 1`] = `
 <View
+  cardColor={undefined}
   style={
     Object {
-      "backgroundColor": "#fff",
+      "backgroundColor": "#ffffff",
       "borderRadius": 6,
       "shadowColor": "#dddddd",
       "shadowOffset": Object {
@@ -100,6 +145,7 @@ exports[`the Card component should render children 1`] = `
       },
       "shadowOpacity": 1,
       "shadowRadius": 3,
+      "width": "100%",
     }
   }
 >

--- a/src/@ui/CardWrapper/__snapshots__/CardWrapper.tests.js.snap
+++ b/src/@ui/CardWrapper/__snapshots__/CardWrapper.tests.js.snap
@@ -22,7 +22,6 @@ exports[`the Card component should accept a backgroundColor 1`] = `
     style={
       Object {
         "borderRadius": 6,
-        "flex": 1,
         "overflow": "hidden",
       }
     }
@@ -62,7 +61,6 @@ exports[`the Card component should accept additional props 1`] = `
     style={
       Object {
         "borderRadius": 6,
-        "flex": 1,
         "overflow": "hidden",
       }
     }
@@ -93,7 +91,6 @@ exports[`the Card component should accept and render passed in styles 1`] = `
     style={
       Object {
         "borderRadius": 6,
-        "flex": 1,
         "overflow": "hidden",
       }
     }
@@ -123,7 +120,6 @@ exports[`the Card component should render 1`] = `
     style={
       Object {
         "borderRadius": 6,
-        "flex": 1,
         "overflow": "hidden",
       }
     }
@@ -153,7 +149,6 @@ exports[`the Card component should render children 1`] = `
     style={
       Object {
         "borderRadius": 6,
-        "flex": 1,
         "overflow": "hidden",
       }
     }

--- a/src/@ui/CardWrapper/index.js
+++ b/src/@ui/CardWrapper/index.js
@@ -17,23 +17,7 @@ const StyledCard = styled(({ theme, cardColor }) => ({
   width: '100%',
   backgroundColor: cardColor || theme.colors.lightPrimary,
   borderRadius: theme.sizing.borderRadius,
-  ...Platform.select({
-    ios: {
-      shadowColor: theme.colors.lightTertiary,
-      shadowOffset: {
-        width: 0,
-        height: 1,
-      },
-      shadowOpacity: 1,
-      shadowRadius: 3,
-    },
-    android: {
-      elevation: 3,
-    },
-    web: {
-      boxShadow: `0 1px 4px ${theme.colors.lightTertiary}`,
-    },
-  }),
+  ...Platform.select(theme.shadows.default),
 }))(View);
 
 /*

--- a/src/@ui/CardWrapper/index.js
+++ b/src/@ui/CardWrapper/index.js
@@ -7,17 +7,19 @@ import styled from '@ui/styled';
 const enhance = compose(
   pure,
   setPropTypes({
+    backgroundColor: PropTypes.string,
     children: PropTypes.node,
     style: PropTypes.any, // eslint-disable-line
   }),
 );
 
-const StyledCard = styled(({ theme }) => ({
-  backgroundColor: theme.colors.background.default,
+const StyledCard = styled(({ theme, cardColor }) => ({
+  width: '100%',
+  backgroundColor: cardColor || theme.colors.lightPrimary,
   borderRadius: theme.sizing.borderRadius,
   ...Platform.select({
     ios: {
-      shadowColor: theme.colors.shadows.default,
+      shadowColor: theme.colors.lightTertiary,
       shadowOffset: {
         width: 0,
         height: 1,
@@ -26,7 +28,10 @@ const StyledCard = styled(({ theme }) => ({
       shadowRadius: 3,
     },
     android: {
-      elevation: 1,
+      elevation: 3,
+    },
+    web: {
+      boxShadow: `0 1px 4px ${theme.colors.lightTertiary}`,
     },
   }),
 }))(View);
@@ -39,10 +44,12 @@ const OverflowFix = styled(({ theme }) => ({
 
 const CardWrapper = enhance(({
   children,
+  backgroundColor,
   style: styleProp = {},
   ...otherProps
 }) => (
   <StyledCard
+    cardColor={backgroundColor}
     style={styleProp}
     {...otherProps}
   >

--- a/src/@ui/CardWrapper/index.js
+++ b/src/@ui/CardWrapper/index.js
@@ -36,8 +36,11 @@ const StyledCard = styled(({ theme, cardColor }) => ({
   }),
 }))(View);
 
+/*
+ * Overflow on iOS, when declared on the same element as a shadow, clips the shadow so overflow must
+ * live on a child wrapper. https://github.com/facebook/react-native/issues/449
+ */
 const OverflowFix = styled(({ theme }) => ({
-  flex: 1,
   borderRadius: theme.sizing.borderRadius,
   overflow: 'hidden',
 }))(View);

--- a/src/@ui/CategoryLabel/CategoryLabel.stories.js
+++ b/src/@ui/CategoryLabel/CategoryLabel.stories.js
@@ -4,18 +4,43 @@ import { storiesOf } from '@storybook/react-native';
 
 import Category from './';
 
-storiesOf('@ui/FeedItemCard/Category', module)
+storiesOf('@ui/CategoryLabel', module)
   .add('Default', () => {
     const centered = {
       justifyContent: 'center',
       alignItems: 'center',
       flex: 1,
-      backgroundColor: '#f7f7f7',
+    };
+
+    return (
+      <View style={centered}>
+        <Category type={'Default'} />
+      </View>
+    );
+  })
+  .add('Series', () => {
+    const centered = {
+      justifyContent: 'center',
+      alignItems: 'center',
+      flex: 1,
     };
 
     return (
       <View style={centered}>
         <Category type={'Series'} />
+      </View>
+    );
+  })
+  .add('Albums', () => {
+    const centered = {
+      justifyContent: 'center',
+      alignItems: 'center',
+      flex: 1,
+    };
+
+    return (
+      <View style={centered}>
+        <Category type={'Albums'} />
       </View>
     );
   });

--- a/src/@ui/CategoryLabel/CategoryLabel.tests.js
+++ b/src/@ui/CategoryLabel/CategoryLabel.tests.js
@@ -8,7 +8,23 @@ describe('the FeedItemCard Category component', () => {
   it('should render', () => {
     const tree = renderer.create(
       <ThemeProvider>
+        <Category type={'Default'} />
+      </ThemeProvider>,
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render as a Series', () => {
+    const tree = renderer.create(
+      <ThemeProvider>
         <Category type={'Series'} />
+      </ThemeProvider>,
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render as Albums', () => {
+    const tree = renderer.create(
+      <ThemeProvider>
+        <Category type={'Albums'} />
       </ThemeProvider>,
     );
     expect(tree).toMatchSnapshot();

--- a/src/@ui/CategoryLabel/__snapshots__/CategoryLabel.tests.js.snap
+++ b/src/@ui/CategoryLabel/__snapshots__/CategoryLabel.tests.js.snap
@@ -19,19 +19,107 @@ exports[`the FeedItemCard Category component should render 1`] = `
     width={21.6}
   >
     <Path
-      d="M3.8182 5.7778v12.4444H14.2V5.7778H3.8182zM16 6v12c0 1.1046-.8954 2-2 2H4c-1.1046 0-2-.8954-2-2V6c0-1.1046.8954-2 2-2h10c1.1046 0 2 .8954 2 2zm4.1818 2.6952L16 11.8084v.3832l4.1818 3.251V8.695zM16 14.4957V9.4253l6-4.2178v13.585l-6-4.2968z"
-      fill="#ffffff"
+      d="M4.6 3.64v16.356c0 .004 0 .004-.003.004h14.806c-.004 0-.003 0-.003-.004V3.64c0-.004 0-.004.003-.004H4.597c.004 0 .003 0 .003.004zm-1.6 0C3 2.734 3.717 2 4.597 2h14.806C20.285 2 21 2.734 21 3.64v16.356c0 .906-.717 1.64-1.597 1.64H4.597c-.882 0-1.597-.734-1.597-1.64V3.64zm4 3.27c0 .45.366.817.818.817h8.364c.452 0 .818-.366.818-.818 0-.454-.366-.82-.818-.82H7.818c-.452 0-.818.366-.818.82zm0 4.908c0 .452.366.818.818.818h8.364c.452 0 .818-.366.818-.818 0-.452-.366-.818-.818-.818H7.818c-.452 0-.818.366-.818.818zm0 4.91c0 .45.366.817.818.817h4.764c.452 0 .818-.366.818-.818 0-.452-.366-.818-.818-.818H7.818c-.452 0-.818.364-.818.816z"
+      fill="#303030"
     />
   </Svg>
   <Text
     accessible={true}
     allowFontScaling={true}
-    color="#ffffff"
+    color="#303030"
     disabled={false}
     ellipsizeMode="tail"
     style={
       Object {
-        "color": "#ffffff",
+        "color": "#303030",
+        "fontFamily": null,
+        "fontSize": 14,
+        "lineHeight": 15.87,
+        "paddingHorizontal": 10,
+      }
+    }
+  >
+    Default
+  </Text>
+</View>
+`;
+
+exports[`the FeedItemCard Category component should render as Albums 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "flexDirection": "row",
+      "paddingBottom": 20,
+      "paddingHorizontal": 20,
+      "paddingTop": 10,
+    }
+  }
+>
+  <Svg
+    height={21.6}
+    viewBox="0 0 24 24"
+    width={21.6}
+  >
+    <Path
+      d="M3.82 13.5H2v-.32C2 6.54 5.22 2 12 2c6.5 0 9.64 4.16 9.98 10.42v1.07h-1.82v-1c-.3-5.8-3.02-8.8-8.16-8.8-5.37 0-8.18 3.32-8.18 9.45v.3zm0 1.7h1.6c.87 0 1.58.66 1.58 1.48v2.13c0 .86-.7 1.5-1.6 1.5-.87 0-1.58-.64-1.58-1.5v-3.6zm0-1.7h1.6c1.87 0 3.4 1.42 3.4 3.18v2.13c0 1.8-1.53 3.2-3.4 3.2C3.5 22 2 20.6 2 18.8v-5.3h1.82zm16.36 1.7v3.6c0 .83-.7 1.5-1.6 1.5-.87 0-1.58-.67-1.58-1.5v-2.1c0-.82.7-1.5 1.6-1.5h1.58zm0-1.7H22v5.3c0 1.77-1.53 3.2-3.4 3.2-1.9 0-3.42-1.43-3.42-3.2v-2.1c0-1.76 1.53-3.2 3.4-3.2h1.6z"
+      fill="#303030"
+    />
+  </Svg>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    color="#303030"
+    disabled={false}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "color": "#303030",
+        "fontFamily": null,
+        "fontSize": 14,
+        "lineHeight": 15.87,
+        "paddingHorizontal": 10,
+      }
+    }
+  >
+    Albums
+  </Text>
+</View>
+`;
+
+exports[`the FeedItemCard Category component should render as a Series 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "flex": 1,
+      "flexDirection": "row",
+      "paddingBottom": 20,
+      "paddingHorizontal": 20,
+      "paddingTop": 10,
+    }
+  }
+>
+  <Svg
+    height={21.6}
+    viewBox="0 0 24 24"
+    width={21.6}
+  >
+    <Path
+      d="M3.8182 5.7778v12.4444H14.2V5.7778H3.8182zM16 6v12c0 1.1046-.8954 2-2 2H4c-1.1046 0-2-.8954-2-2V6c0-1.1046.8954-2 2-2h10c1.1046 0 2 .8954 2 2zm4.1818 2.6952L16 11.8084v.3832l4.1818 3.251V8.695zM16 14.4957V9.4253l6-4.2178v13.585l-6-4.2968z"
+      fill="#303030"
+    />
+  </Svg>
+  <Text
+    accessible={true}
+    allowFontScaling={true}
+    color="#303030"
+    disabled={false}
+    ellipsizeMode="tail"
+    style={
+      Object {
+        "color": "#303030",
         "fontFamily": null,
         "fontSize": 14,
         "lineHeight": 15.87,

--- a/src/@ui/CategoryLabel/index.js
+++ b/src/@ui/CategoryLabel/index.js
@@ -11,7 +11,7 @@ import Icon from '@ui/Icon';
 const enhance = compose(
   pure,
   withTheme(({ theme, color }) => ({
-    color: color || theme.colors.lightPrimary,
+    color: color || theme.colors.text.primary,
     theme,
   })),
   setPropTypes({

--- a/src/@ui/FeedItemCard/CardImage/CardImage.stories.js
+++ b/src/@ui/FeedItemCard/CardImage/CardImage.stories.js
@@ -10,12 +10,24 @@ storiesOf('@primitives/FeedItemCard/CardImage', module)
       justifyContent: 'center',
       alignItems: 'center',
       flex: 1,
-      backgroundColor: '#f7f7f7',
     };
 
     return (
       <View style={centered}>
-        <CardImage source={'https://picsum.photos/600/400/?random'} overlayColor={'#ffffff'} />
+        <CardImage source={'https://picsum.photos/600/400/?random'} />
+      </View>
+    );
+  })
+  .add('With Overlay', () => {
+    const centered = {
+      justifyContent: 'center',
+      alignItems: 'center',
+      flex: 1,
+    };
+
+    return (
+      <View style={centered}>
+        <CardImage source={'https://picsum.photos/600/400/?random'} overlayColor={'salmon'} />
       </View>
     );
   });

--- a/src/@ui/FeedItemCard/CardImage/CardImage.stories.js
+++ b/src/@ui/FeedItemCard/CardImage/CardImage.stories.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react-native';
 
 import CardImage from './';
 
-storiesOf('@primitives/FeedItemCard/CardImage', module)
+storiesOf('@ui/FeedItemCard/CardImage', module)
   .add('Default', () => {
     const centered = {
       justifyContent: 'center',

--- a/src/@ui/FeedItemCard/CardImage/CardImage.tests.js
+++ b/src/@ui/FeedItemCard/CardImage/CardImage.tests.js
@@ -4,11 +4,19 @@ import renderer from 'react-test-renderer';
 import { ThemeProvider } from '@ui/theme';
 import CardImage from './';
 
-describe('the FeedItemCard Category component', () => {
+describe('the FeedItemCard CardImage component', () => {
   it('should render', () => {
     const tree = renderer.create(
       <ThemeProvider>
-        <CardImage source={'https://picsum.photos/600/400/?random'} overlayColor={'#ffffff'} />
+        <CardImage source={'https://picsum.photos/600/400/?random'} />
+      </ThemeProvider>,
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render with an overlayColor', () => {
+    const tree = renderer.create(
+      <ThemeProvider>
+        <CardImage source={'https://picsum.photos/600/400/?random'} overlayColor={'salmon'} />
       </ThemeProvider>,
     );
     expect(tree).toMatchSnapshot();

--- a/src/@ui/FeedItemCard/CardImage/__snapshots__/CardImage.tests.js.snap
+++ b/src/@ui/FeedItemCard/CardImage/__snapshots__/CardImage.tests.js.snap
@@ -1,12 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`the FeedItemCard Category component should render 1`] = `
+exports[`the FeedItemCard CardImage component should render 1`] = `
 <View
-  style={
-    Object {
-      "flex": 1,
-    }
-  }
+  style={Object {}}
 >
   <Image
     source={
@@ -20,7 +16,30 @@ exports[`the FeedItemCard Category component should render 1`] = `
     style={
       Object {
         "aspectRatio": 1,
-        "flex": 1,
+        "resizeMode": "cover",
+        "width": "100%",
+      }
+    }
+  />
+</View>
+`;
+
+exports[`the FeedItemCard CardImage component should render with an overlayColor 1`] = `
+<View
+  style={Object {}}
+>
+  <Image
+    source={
+      Array [
+        Object {
+          "uri": "https://picsum.photos/600/400/?random",
+          "url": "https://picsum.photos/600/400/?random",
+        },
+      ]
+    }
+    style={
+      Object {
+        "aspectRatio": 1,
         "resizeMode": "cover",
         "width": "100%",
       }
@@ -29,8 +48,8 @@ exports[`the FeedItemCard Category component should render 1`] = `
   <ExponentLinearGradient
     colors={
       Array [
-        16777215,
-        4294967295,
+        16416882,
+        4294606962,
       ]
     }
     end={

--- a/src/@ui/FeedItemCard/CardImage/index.js
+++ b/src/@ui/FeedItemCard/CardImage/index.js
@@ -26,7 +26,6 @@ const enhance = compose(
 );
 
 const Wrapper = styled(({ theme }) => ({
-  flex: 1,
   ...Platform.select({
     android: { // fixes android borderRadius overflow display issue
       borderTopRightRadius: theme.sizing.borderRadius,
@@ -37,7 +36,6 @@ const Wrapper = styled(({ theme }) => ({
 
 const StyledImage = styled(({ theme }) => ({
   width: '100%',
-  flex: 1,
   aspectRatio: 1,
   resizeMode: 'cover',
   ...Platform.select({

--- a/src/@ui/FeedItemCard/FeedItemCard.stories.js
+++ b/src/@ui/FeedItemCard/FeedItemCard.stories.js
@@ -4,7 +4,7 @@ import { storiesOf } from '@storybook/react-native';
 
 import FeedItemCard from './';
 
-storiesOf('@primitives/FeedItemCard/Component', module)
+storiesOf('@ui/FeedItemCard/Component', module)
   .add('Default', () => {
     const centered = {
       justifyContent: 'center',

--- a/src/@ui/FeedItemCard/FeedItemCard.stories.js
+++ b/src/@ui/FeedItemCard/FeedItemCard.stories.js
@@ -17,13 +17,12 @@ storiesOf('@primitives/FeedItemCard/Component', module)
         <FeedItemCard
           title={'Promised Land'}
           category={'Series'}
-          image={'https://picsum.photos/600/400/?random'}
-          isLight
+          images={'https://picsum.photos/600/400/?random'}
         />
       </View>
     );
   })
-  .add('With cardColor', () => {
+  .add('With dark backgroundColor', () => {
     const centered = {
       justifyContent: 'center',
       flex: 1,
@@ -34,9 +33,27 @@ storiesOf('@primitives/FeedItemCard/Component', module)
         <FeedItemCard
           title={'Promised Land'}
           category={'Series'}
-          image={'https://picsum.photos/600/400/?random'}
-          cardColor={'salmon'}
+          images={'https://picsum.photos/600/400/?random'}
+          backgroundColor={'salmon'}
           isLight={false}
+        />
+      </View>
+    );
+  })
+  .add('With isLight and light backgroundColor', () => {
+    const centered = {
+      justifyContent: 'center',
+      flex: 1,
+      backgroundColor: '#f7f7f7',
+    };
+    return (
+      <View style={centered}>
+        <FeedItemCard
+          title={'Promised Land'}
+          category={'Series'}
+          images={'https://picsum.photos/600/400/?random'}
+          backgroundColor={'papayawhip'}
+          isLight
         />
       </View>
     );
@@ -52,14 +69,13 @@ storiesOf('@primitives/FeedItemCard/Component', module)
         <FeedItemCard
           title={'Promised Land'}
           category={'Series'}
-          image={'https://picsum.photos/600/400/?random'}
-          isLight
+          images={'https://picsum.photos/600/400/?random'}
           isLiked
         />
       </View>
     );
   })
-  .add('As liked with cardColor', () => {
+  .add('As liked with backgroundColor', () => {
     const centered = {
       justifyContent: 'center',
       flex: 1,
@@ -70,9 +86,28 @@ storiesOf('@primitives/FeedItemCard/Component', module)
         <FeedItemCard
           title={'Promised Land'}
           category={'Series'}
-          image={'https://picsum.photos/600/400/?random'}
-          cardColor={'salmon'}
+          images={'https://picsum.photos/600/400/?random'}
+          backgroundColor={'salmon'}
           isLight={false}
+          isLiked
+        />
+      </View>
+    );
+  })
+  .add('As liked with isLight and light backgroundColor', () => {
+    const centered = {
+      justifyContent: 'center',
+      flex: 1,
+      backgroundColor: '#f7f7f7',
+    };
+    return (
+      <View style={centered}>
+        <FeedItemCard
+          title={'Promised Land'}
+          category={'Series'}
+          images={'https://picsum.photos/600/400/?random'}
+          backgroundColor={'papayawhip'}
+          isLight
           isLiked
         />
       </View>

--- a/src/@ui/FeedItemCard/FeedItemCard.tests.js
+++ b/src/@ui/FeedItemCard/FeedItemCard.tests.js
@@ -10,36 +10,47 @@ describe('the FeedItemCard component', () => {
       <ThemeProvider>
         <FeedItemCard
           title={'Boom'}
-          images={'https://picsum.photos/600/400/?random'}
           category={'What'}
+          images={'https://picsum.photos/600/400/?random'}
+        />
+      </ThemeProvider>,
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render with inverted (light) font colors', () => {
+    const tree = renderer.create(
+      <ThemeProvider>
+        <FeedItemCard
+          title={'Boom'}
+          category={'What'}
+          images={'https://picsum.photos/600/400/?random'}
+          isLight={false}
+        />
+      </ThemeProvider>,
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should accept a different backgroundColor', () => {
+    const tree = renderer.create(
+      <ThemeProvider>
+        <FeedItemCard
+          title={'Boom'}
+          category={'What'}
+          images={'https://picsum.photos/600/400/?random'}
+          backgroundColor={'salmon'}
+        />
+      </ThemeProvider>,
+    );
+    expect(tree).toMatchSnapshot();
+  });
+  it('should render text correctly with isLight', () => {
+    const tree = renderer.create(
+      <ThemeProvider>
+        <FeedItemCard
+          title={'Boom'}
+          category={'What'}
+          images={'https://picsum.photos/600/400/?random'}
           isLight
-        />
-      </ThemeProvider>,
-    );
-    expect(tree).toMatchSnapshot();
-  });
-  it('should render with inverted font colors', () => {
-    const tree = renderer.create(
-      <ThemeProvider>
-        <FeedItemCard
-          title={'Boom'}
-          images={'https://picsum.photos/600/400/?random'}
-          category={'What'}
-          isLight={false}
-        />
-      </ThemeProvider>,
-    );
-    expect(tree).toMatchSnapshot();
-  });
-  it('should accept a different card color', () => {
-    const tree = renderer.create(
-      <ThemeProvider>
-        <FeedItemCard
-          title={'Boom'}
-          images={'https://picsum.photos/600/400/?random'}
-          category={'What'}
-          cardColor={'salmon'}
-          isLight={false}
         />
       </ThemeProvider>,
     );
@@ -50,9 +61,8 @@ describe('the FeedItemCard component', () => {
       <ThemeProvider>
         <FeedItemCard
           title={'Boom'}
-          images={'https://picsum.photos/600/400/?random'}
           category={'What'}
-          isLight
+          images={'https://picsum.photos/600/400/?random'}
           isLiked
         />
       </ThemeProvider>,
@@ -69,10 +79,9 @@ describe('the FeedItemCard component', () => {
       <ThemeProvider>
         <FeedItemCard
           title={'Boom'}
-          images={'https://picsum.photos/600/400/?random'}
           category={'What'}
+          images={'https://picsum.photos/600/400/?random'}
           style={cardDimensions}
-          isLight
         />
       </ThemeProvider>,
     );

--- a/src/@ui/FeedItemCard/FeedItemCard.tests.js
+++ b/src/@ui/FeedItemCard/FeedItemCard.tests.js
@@ -10,7 +10,7 @@ describe('the FeedItemCard component', () => {
       <ThemeProvider>
         <FeedItemCard
           title={'Boom'}
-          image={'https://picsum.photos/600/400/?random'}
+          images={'https://picsum.photos/600/400/?random'}
           category={'What'}
           isLight
         />
@@ -23,7 +23,7 @@ describe('the FeedItemCard component', () => {
       <ThemeProvider>
         <FeedItemCard
           title={'Boom'}
-          image={'https://picsum.photos/600/400/?random'}
+          images={'https://picsum.photos/600/400/?random'}
           category={'What'}
           isLight={false}
         />
@@ -36,7 +36,7 @@ describe('the FeedItemCard component', () => {
       <ThemeProvider>
         <FeedItemCard
           title={'Boom'}
-          image={'https://picsum.photos/600/400/?random'}
+          images={'https://picsum.photos/600/400/?random'}
           category={'What'}
           cardColor={'salmon'}
           isLight={false}
@@ -50,7 +50,7 @@ describe('the FeedItemCard component', () => {
       <ThemeProvider>
         <FeedItemCard
           title={'Boom'}
-          image={'https://picsum.photos/600/400/?random'}
+          images={'https://picsum.photos/600/400/?random'}
           category={'What'}
           isLight
           isLiked
@@ -69,7 +69,7 @@ describe('the FeedItemCard component', () => {
       <ThemeProvider>
         <FeedItemCard
           title={'Boom'}
-          image={'https://picsum.photos/600/400/?random'}
+          images={'https://picsum.photos/600/400/?random'}
           category={'What'}
           style={cardDimensions}
           isLight

--- a/src/@ui/FeedItemCard/__snapshots__/FeedItemCard.tests.js.snap
+++ b/src/@ui/FeedItemCard/__snapshots__/FeedItemCard.tests.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`the FeedItemCard component should accept a different card color 1`] = `
+exports[`the FeedItemCard component should accept a different backgroundColor 1`] = `
 <View
   style={
     Object {
@@ -11,13 +11,10 @@ exports[`the FeedItemCard component should accept a different card color 1`] = `
 >
   <View
     cardColor="salmon"
-    image="https://picsum.photos/600/400/?random"
-    isLight={false}
     style={
       Object {
         "backgroundColor": "salmon",
         "borderRadius": 6,
-        "minHeight": 400,
         "shadowColor": "#dddddd",
         "shadowOffset": Object {
           "height": 1,
@@ -33,26 +30,62 @@ exports[`the FeedItemCard component should accept a different card color 1`] = `
       style={
         Object {
           "borderRadius": 6,
-          "flex": 1,
           "overflow": "hidden",
         }
       }
     >
       <View
-        style={
-          Object {
-            "flex": 1,
-          }
-        }
+        style={Object {}}
       >
         <Image
-          source={Array []}
+          source={
+            Array [
+              Object {
+                "uri": "https://picsum.photos/600/400/?random",
+                "url": "https://picsum.photos/600/400/?random",
+              },
+            ]
+          }
           style={
             Object {
               "aspectRatio": 1,
-              "flex": 1,
               "resizeMode": "cover",
               "width": "100%",
+            }
+          }
+        />
+        <ExponentLinearGradient
+          colors={
+            Array [
+              16416882,
+              4294606962,
+            ]
+          }
+          end={
+            Array [
+              0,
+              1,
+            ]
+          }
+          locations={
+            Array [
+              0.3,
+              1,
+            ]
+          }
+          start={
+            Array [
+              0,
+              0,
+            ]
+          }
+          style={
+            Object {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
             }
           }
         />
@@ -60,13 +93,12 @@ exports[`the FeedItemCard component should accept a different card color 1`] = `
       <Text
         accessible={true}
         allowFontScaling={true}
-        color="#ffffff"
+        color="#303030"
         disabled={false}
         ellipsizeMode="tail"
         style={
           Object {
-            "color": "#ffffff",
-            "flex": 0,
+            "color": "#303030",
             "fontFamily": null,
             "fontSize": 25.2,
             "fontWeight": "700",
@@ -105,18 +137,18 @@ exports[`the FeedItemCard component should accept a different card color 1`] = `
           >
             <Path
               d="M4.6 3.64v16.356c0 .004 0 .004-.003.004h14.806c-.004 0-.003 0-.003-.004V3.64c0-.004 0-.004.003-.004H4.597c.004 0 .003 0 .003.004zm-1.6 0C3 2.734 3.717 2 4.597 2h14.806C20.285 2 21 2.734 21 3.64v16.356c0 .906-.717 1.64-1.597 1.64H4.597c-.882 0-1.597-.734-1.597-1.64V3.64zm4 3.27c0 .45.366.817.818.817h8.364c.452 0 .818-.366.818-.818 0-.454-.366-.82-.818-.82H7.818c-.452 0-.818.366-.818.82zm0 4.908c0 .452.366.818.818.818h8.364c.452 0 .818-.366.818-.818 0-.452-.366-.818-.818-.818H7.818c-.452 0-.818.366-.818.818zm0 4.91c0 .45.366.817.818.817h4.764c.452 0 .818-.366.818-.818 0-.452-.366-.818-.818-.818H7.818c-.452 0-.818.364-.818.816z"
-              fill="#ffffff"
+              fill="#303030"
             />
           </Svg>
           <Text
             accessible={true}
             allowFontScaling={true}
-            color="#ffffff"
+            color="#303030"
             disabled={false}
             ellipsizeMode="tail"
             style={
               Object {
-                "color": "#ffffff",
+                "color": "#303030",
                 "fontFamily": null,
                 "fontSize": 14,
                 "lineHeight": 15.87,
@@ -161,7 +193,7 @@ exports[`the FeedItemCard component should accept a different card color 1`] = `
           >
             <Path
               d="M13.13 20.2h-2.26l1.4-1.4.03-.02.03-.03c6.37-5.6 8.06-7.67 8.06-10.27 0-2.2-1.7-3.9-3.9-3.9-1.23 0-2.48.6-3.28 1.54L12 7.57l-1.23-1.45C9.97 5.18 8.72 4.6 7.5 4.6c-2.2 0-3.9 1.67-3.9 3.88 0 2.6 1.7 4.66 8.07 10.27l.03.03.04.03 1.4 1.4zM10.8 4.03l-.03.03h.1c.4.3.8.64 1.13 1.03.33-.4.72-.75 1.14-1.05h.1c-.02 0-.03-.02-.04-.03.97-.66 2.13-1.03 3.3-1.03C19.6 3 22 5.4 22 8.47c0 3.8-3.4 6.88-8.6 11.46l-1.4 1.4-1.4-1.4C5.4 15.36 2 12.27 2 8.48 2 5.38 4.4 3 7.5 3c1.17 0 2.33.37 3.3 1.03z"
-              fill="#ffffff"
+              fill="#303030"
             />
           </Svg>
         </View>
@@ -182,14 +214,11 @@ exports[`the FeedItemCard component should accept and render passed in styles 1`
 >
   <View
     cardColor={undefined}
-    image="https://picsum.photos/600/400/?random"
-    isLight={true}
     style={
       Object {
         "backgroundColor": "#ffffff",
         "borderRadius": 6,
         "height": 400,
-        "minHeight": 400,
         "shadowColor": "#dddddd",
         "shadowOffset": Object {
           "height": 1,
@@ -205,24 +234,25 @@ exports[`the FeedItemCard component should accept and render passed in styles 1`
       style={
         Object {
           "borderRadius": 6,
-          "flex": 1,
           "overflow": "hidden",
         }
       }
     >
       <View
-        style={
-          Object {
-            "flex": 1,
-          }
-        }
+        style={Object {}}
       >
         <Image
-          source={Array []}
+          source={
+            Array [
+              Object {
+                "uri": "https://picsum.photos/600/400/?random",
+                "url": "https://picsum.photos/600/400/?random",
+              },
+            ]
+          }
           style={
             Object {
               "aspectRatio": 1,
-              "flex": 1,
               "resizeMode": "cover",
               "width": "100%",
             }
@@ -238,7 +268,6 @@ exports[`the FeedItemCard component should accept and render passed in styles 1`
         style={
           Object {
             "color": "#303030",
-            "flex": 0,
             "fontFamily": null,
             "fontSize": 25.2,
             "fontWeight": "700",
@@ -354,13 +383,10 @@ exports[`the FeedItemCard component should render 1`] = `
 >
   <View
     cardColor={undefined}
-    image="https://picsum.photos/600/400/?random"
-    isLight={true}
     style={
       Object {
         "backgroundColor": "#ffffff",
         "borderRadius": 6,
-        "minHeight": 400,
         "shadowColor": "#dddddd",
         "shadowOffset": Object {
           "height": 1,
@@ -376,24 +402,25 @@ exports[`the FeedItemCard component should render 1`] = `
       style={
         Object {
           "borderRadius": 6,
-          "flex": 1,
           "overflow": "hidden",
         }
       }
     >
       <View
-        style={
-          Object {
-            "flex": 1,
-          }
-        }
+        style={Object {}}
       >
         <Image
-          source={Array []}
+          source={
+            Array [
+              Object {
+                "uri": "https://picsum.photos/600/400/?random",
+                "url": "https://picsum.photos/600/400/?random",
+              },
+            ]
+          }
           style={
             Object {
               "aspectRatio": 1,
-              "flex": 1,
               "resizeMode": "cover",
               "width": "100%",
             }
@@ -409,7 +436,6 @@ exports[`the FeedItemCard component should render 1`] = `
         style={
           Object {
             "color": "#303030",
-            "flex": 0,
             "fontFamily": null,
             "fontSize": 25.2,
             "fontWeight": "700",
@@ -525,14 +551,10 @@ exports[`the FeedItemCard component should render as liked 1`] = `
 >
   <View
     cardColor={undefined}
-    image="https://picsum.photos/600/400/?random"
-    isLight={true}
-    isLiked={true}
     style={
       Object {
         "backgroundColor": "#ffffff",
         "borderRadius": 6,
-        "minHeight": 400,
         "shadowColor": "#dddddd",
         "shadowOffset": Object {
           "height": 1,
@@ -548,24 +570,25 @@ exports[`the FeedItemCard component should render as liked 1`] = `
       style={
         Object {
           "borderRadius": 6,
-          "flex": 1,
           "overflow": "hidden",
         }
       }
     >
       <View
-        style={
-          Object {
-            "flex": 1,
-          }
-        }
+        style={Object {}}
       >
         <Image
-          source={Array []}
+          source={
+            Array [
+              Object {
+                "uri": "https://picsum.photos/600/400/?random",
+                "url": "https://picsum.photos/600/400/?random",
+              },
+            ]
+          }
           style={
             Object {
               "aspectRatio": 1,
-              "flex": 1,
               "resizeMode": "cover",
               "width": "100%",
             }
@@ -581,7 +604,175 @@ exports[`the FeedItemCard component should render as liked 1`] = `
         style={
           Object {
             "color": "#303030",
-            "flex": 0,
+            "fontFamily": null,
+            "fontSize": 25.2,
+            "fontWeight": "700",
+            "lineHeight": 31.28,
+            "paddingHorizontal": 20,
+            "paddingTop": 20,
+          }
+        }
+      >
+        Boom
+      </Text>
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flexDirection": "row",
+          }
+        }
+      >
+        <View
+          style={
+            Object {
+              "alignItems": "center",
+              "flex": 1,
+              "flexDirection": "row",
+              "paddingBottom": 20,
+              "paddingHorizontal": 20,
+              "paddingTop": 10,
+            }
+          }
+        >
+          <Svg
+            height={21.6}
+            viewBox="0 0 24 24"
+            width={21.6}
+          >
+            <Path
+              d="M4.6 3.64v16.356c0 .004 0 .004-.003.004h14.806c-.004 0-.003 0-.003-.004V3.64c0-.004 0-.004.003-.004H4.597c.004 0 .003 0 .003.004zm-1.6 0C3 2.734 3.717 2 4.597 2h14.806C20.285 2 21 2.734 21 3.64v16.356c0 .906-.717 1.64-1.597 1.64H4.597c-.882 0-1.597-.734-1.597-1.64V3.64zm4 3.27c0 .45.366.817.818.817h8.364c.452 0 .818-.366.818-.818 0-.454-.366-.82-.818-.82H7.818c-.452 0-.818.366-.818.82zm0 4.908c0 .452.366.818.818.818h8.364c.452 0 .818-.366.818-.818 0-.452-.366-.818-.818-.818H7.818c-.452 0-.818.366-.818.818zm0 4.91c0 .45.366.817.818.817h4.764c.452 0 .818-.366.818-.818 0-.452-.366-.818-.818-.818H7.818c-.452 0-.818.364-.818.816z"
+              fill="#303030"
+            />
+          </Svg>
+          <Text
+            accessible={true}
+            allowFontScaling={true}
+            color="#303030"
+            disabled={false}
+            ellipsizeMode="tail"
+            style={
+              Object {
+                "color": "#303030",
+                "fontFamily": null,
+                "fontSize": 14,
+                "lineHeight": 15.87,
+                "paddingHorizontal": 10,
+              }
+            }
+          >
+            What
+          </Text>
+        </View>
+        <View
+          accessibilityComponentType={undefined}
+          accessibilityLabel={undefined}
+          accessibilityTraits={undefined}
+          accessible={true}
+          collapsable={undefined}
+          hitSlop={undefined}
+          isTVSelectable={true}
+          nativeID={undefined}
+          onLayout={undefined}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "opacity": 1,
+              "paddingBottom": 20,
+              "paddingHorizontal": 20,
+              "paddingTop": 10,
+            }
+          }
+          testID={undefined}
+          tvParallaxProperties={undefined}
+        >
+          <Svg
+            height={21.6}
+            viewBox="0 0 24 24"
+            width={21.6}
+          >
+            <Path
+              d="M10.8 4.03l-.03.03h.1c.4.3.8.64 1.13 1.03.33-.4.72-.75 1.14-1.05h.1c-.02 0-.03-.02-.04-.03.97-.66 2.13-1.03 3.3-1.03C19.6 3 22 5.4 22 8.47c0 3.8-3.4 6.88-8.6 11.46l-1.4 1.4-1.4-1.4C5.4 15.36 2 12.27 2 8.48 2 5.38 4.4 3 7.5 3c1.17 0 2.33.37 3.3 1.03z"
+              fill="#303030"
+            />
+          </Svg>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
+exports[`the FeedItemCard component should render text correctly with isLight 1`] = `
+<View
+  style={
+    Object {
+      "marginHorizontal": 10,
+      "marginVertical": 5,
+    }
+  }
+>
+  <View
+    cardColor={undefined}
+    isLight={true}
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+        "borderRadius": 6,
+        "shadowColor": "#dddddd",
+        "shadowOffset": Object {
+          "height": 1,
+          "width": 0,
+        },
+        "shadowOpacity": 1,
+        "shadowRadius": 3,
+        "width": "100%",
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "borderRadius": 6,
+          "overflow": "hidden",
+        }
+      }
+    >
+      <View
+        style={Object {}}
+      >
+        <Image
+          source={
+            Array [
+              Object {
+                "uri": "https://picsum.photos/600/400/?random",
+                "url": "https://picsum.photos/600/400/?random",
+              },
+            ]
+          }
+          style={
+            Object {
+              "aspectRatio": 1,
+              "resizeMode": "cover",
+              "width": "100%",
+            }
+          }
+        />
+      </View>
+      <Text
+        accessible={true}
+        allowFontScaling={true}
+        color="#303030"
+        disabled={false}
+        ellipsizeMode="tail"
+        style={
+          Object {
+            "color": "#303030",
             "fontFamily": null,
             "fontSize": 25.2,
             "fontWeight": "700",
@@ -686,7 +877,7 @@ exports[`the FeedItemCard component should render as liked 1`] = `
 </View>
 `;
 
-exports[`the FeedItemCard component should render with inverted font colors 1`] = `
+exports[`the FeedItemCard component should render with inverted (light) font colors 1`] = `
 <View
   style={
     Object {
@@ -697,13 +888,11 @@ exports[`the FeedItemCard component should render with inverted font colors 1`] 
 >
   <View
     cardColor={undefined}
-    image="https://picsum.photos/600/400/?random"
     isLight={false}
     style={
       Object {
         "backgroundColor": "#ffffff",
         "borderRadius": 6,
-        "minHeight": 400,
         "shadowColor": "#dddddd",
         "shadowOffset": Object {
           "height": 1,
@@ -719,24 +908,25 @@ exports[`the FeedItemCard component should render with inverted font colors 1`] 
       style={
         Object {
           "borderRadius": 6,
-          "flex": 1,
           "overflow": "hidden",
         }
       }
     >
       <View
-        style={
-          Object {
-            "flex": 1,
-          }
-        }
+        style={Object {}}
       >
         <Image
-          source={Array []}
+          source={
+            Array [
+              Object {
+                "uri": "https://picsum.photos/600/400/?random",
+                "url": "https://picsum.photos/600/400/?random",
+              },
+            ]
+          }
           style={
             Object {
               "aspectRatio": 1,
-              "flex": 1,
               "resizeMode": "cover",
               "width": "100%",
             }
@@ -752,7 +942,6 @@ exports[`the FeedItemCard component should render with inverted font colors 1`] 
         style={
           Object {
             "color": "#ffffff",
-            "flex": 0,
             "fontFamily": null,
             "fontSize": 25.2,
             "fontWeight": "700",

--- a/src/@ui/FeedItemCard/index.js
+++ b/src/@ui/FeedItemCard/index.js
@@ -7,13 +7,12 @@ import { startCase, toLower } from 'lodash';
 import { withTheme } from '@ui/theme';
 import styled from '@ui/styled';
 import Icon from '@ui/Icon';
+import Card from '@ui/CardWrapper';
 import CategoryLabel from '@ui/CategoryLabel';
 
 import CardImage from './CardImage';
 import {
   CardWrapper,
-  Card,
-  OverflowFix,
   CardTitle,
   Footer,
 } from './styles';
@@ -63,21 +62,19 @@ const FeedItemCard = enhance(({
   ...otherProps
 }) => (
   <CardWrapper>
-    <Card cardColor={backgroundColor} {...otherProps}>
-      <OverflowFix>
-        <CardImage source={images} overlayColor={backgroundColor} />
-        <CardTitle color={fontColor}>{startCase(toLower(title))}</CardTitle>
-        <Footer>
-          <CategoryLabel type={startCase(toLower(category))} color={fontColor} />
-          <LikeButton>
-            <Icon
-              name={isLiked ? 'like-solid' : 'like'}
-              size={theme.helpers.rem(1.2)}
-              fill={fontColor}
-            />
-          </LikeButton>
-        </Footer>
-      </OverflowFix>
+    <Card backgroundColor={backgroundColor} {...otherProps}>
+      <CardImage source={images} overlayColor={backgroundColor} />
+      <CardTitle color={fontColor}>{startCase(toLower(title))}</CardTitle>
+      <Footer>
+        <CategoryLabel type={startCase(toLower(category))} color={fontColor} />
+        <LikeButton>
+          <Icon
+            name={isLiked ? 'like-solid' : 'like'}
+            size={theme.helpers.rem(1.2)}
+            fill={fontColor}
+          />
+        </LikeButton>
+      </Footer>
     </Card>
   </CardWrapper>
 ));

--- a/src/@ui/FeedItemCard/index.js
+++ b/src/@ui/FeedItemCard/index.js
@@ -21,7 +21,9 @@ import {
 const enhance = compose(
   pure,
   withTheme(({ theme, isLight }) => ({
-    fontColor: isLight ? theme.colors.text.primary : theme.colors.lightPrimary,
+    fontColor: (isLight || typeof isLight === 'undefined') ?
+      theme.colors.text.primary :
+      theme.colors.lightPrimary,
     theme,
   })),
   setPropTypes({
@@ -35,7 +37,8 @@ const enhance = compose(
       PropTypes.string,
     ]),
     category: PropTypes.string.isRequired,
-    isLight: PropTypes.bool.isRequired,
+    isLiked: PropTypes.bool,
+    isLight: PropTypes.bool,
     color: PropTypes.string,
     fontColor: PropTypes.string,
     backgroundColor: PropTypes.string,
@@ -53,6 +56,7 @@ const FeedItemCard = enhance(({
   images,
   title,
   category,
+  isLiked,
   fontColor,
   backgroundColor,
   theme,
@@ -66,7 +70,11 @@ const FeedItemCard = enhance(({
         <Footer>
           <CategoryLabel type={startCase(toLower(category))} color={fontColor} />
           <LikeButton>
-            <Icon name={'like'} size={theme.helpers.rem(1.2)} fill={fontColor} />
+            <Icon
+              name={isLiked ? 'like-solid' : 'like'}
+              size={theme.helpers.rem(1.2)}
+              fill={fontColor}
+            />
           </LikeButton>
         </Footer>
       </OverflowFix>

--- a/src/@ui/FeedItemCard/styles.js
+++ b/src/@ui/FeedItemCard/styles.js
@@ -1,6 +1,5 @@
 import {
   View,
-  Platform,
 } from 'react-native';
 
 import styled from '@ui/styled';
@@ -9,38 +8,6 @@ import { H4 } from '@ui/typography';
 const CardWrapper = styled(({ theme }) => ({
   marginHorizontal: theme.sizing.baseUnit / 2,
   marginVertical: theme.sizing.baseUnit / 4,
-}))(View);
-
-const Card = styled(({ theme, cardColor }) => ({
-  width: '100%',
-  backgroundColor: cardColor || theme.colors.lightPrimary,
-  borderRadius: theme.sizing.borderRadius,
-  ...Platform.select({
-    ios: {
-      shadowColor: theme.colors.lightTertiary,
-      shadowOffset: {
-        width: 0,
-        height: 1,
-      },
-      shadowOpacity: 1,
-      shadowRadius: 3,
-    },
-    android: {
-      elevation: 3,
-    },
-    web: {
-      boxShadow: `0 1px 4px ${theme.colors.lightTertiary}`,
-    },
-  }),
-}))(View);
-
-/*
- * Overflow on iOS, when declared on the same element as a shadow, clips the shadow so overflow must
- * live on a child wrapper. https://github.com/facebook/react-native/issues/449
- */
-const OverflowFix = styled(({ theme }) => ({
-  borderRadius: theme.sizing.borderRadius,
-  overflow: 'hidden',
 }))(View);
 
 const CardTitle = styled(({ theme, color: fontColor }) => ({
@@ -56,8 +23,6 @@ const Footer = styled({
 
 export {
   CardWrapper,
-  Card,
-  OverflowFix,
   CardTitle,
   Footer,
 };

--- a/src/@ui/FeedItemCard/styles.js
+++ b/src/@ui/FeedItemCard/styles.js
@@ -13,7 +13,6 @@ const CardWrapper = styled(({ theme }) => ({
 
 const Card = styled(({ theme, cardColor }) => ({
   width: '100%',
-  minHeight: 400,
   backgroundColor: cardColor || theme.colors.lightPrimary,
   borderRadius: theme.sizing.borderRadius,
   ...Platform.select({
@@ -40,13 +39,11 @@ const Card = styled(({ theme, cardColor }) => ({
  * live on a child wrapper. https://github.com/facebook/react-native/issues/449
  */
 const OverflowFix = styled(({ theme }) => ({
-  flex: 1,
   borderRadius: theme.sizing.borderRadius,
   overflow: 'hidden',
 }))(View);
 
 const CardTitle = styled(({ theme, color: fontColor }) => ({
-  flex: 0,
   paddingTop: theme.sizing.baseUnit,
   paddingHorizontal: theme.sizing.baseUnit,
   color: fontColor || theme.colors.text.primary,

--- a/src/@ui/FeedView/__tests__/__snapshots__/FeedView.tests.js.snap
+++ b/src/@ui/FeedView/__tests__/__snapshots__/FeedView.tests.js.snap
@@ -102,7 +102,6 @@ exports[`The FeedView component renders correctly 1`] = `
             Object {
               "backgroundColor": "#ffffff",
               "borderRadius": 6,
-              "minHeight": 400,
               "shadowColor": "#dddddd",
               "shadowOffset": Object {
                 "height": 1,
@@ -119,17 +118,12 @@ exports[`The FeedView component renders correctly 1`] = `
             style={
               Object {
                 "borderRadius": 6,
-                "flex": 1,
                 "overflow": "hidden",
               }
             }
           >
             <View
-              style={
-                Object {
-                  "flex": 1,
-                }
-              }
+              style={Object {}}
             >
               <Image
                 source={
@@ -143,7 +137,6 @@ exports[`The FeedView component renders correctly 1`] = `
                 style={
                   Object {
                     "aspectRatio": 1,
-                    "flex": 1,
                     "resizeMode": "cover",
                     "width": "100%",
                   }
@@ -159,7 +152,6 @@ exports[`The FeedView component renders correctly 1`] = `
               style={
                 Object {
                   "color": "#303030",
-                  "flex": 0,
                   "fontFamily": null,
                   "fontSize": 25.2,
                   "fontWeight": "700",
@@ -295,7 +287,6 @@ exports[`The FeedView component renders correctly 1`] = `
             Object {
               "backgroundColor": "#584068",
               "borderRadius": 6,
-              "minHeight": 400,
               "shadowColor": "#dddddd",
               "shadowOffset": Object {
                 "height": 1,
@@ -312,17 +303,12 @@ exports[`The FeedView component renders correctly 1`] = `
             style={
               Object {
                 "borderRadius": 6,
-                "flex": 1,
                 "overflow": "hidden",
               }
             }
           >
             <View
-              style={
-                Object {
-                  "flex": 1,
-                }
-              }
+              style={Object {}}
             >
               <Image
                 source={
@@ -336,7 +322,6 @@ exports[`The FeedView component renders correctly 1`] = `
                 style={
                   Object {
                     "aspectRatio": 1,
-                    "flex": 1,
                     "resizeMode": "cover",
                     "width": "100%",
                   }
@@ -387,7 +372,6 @@ exports[`The FeedView component renders correctly 1`] = `
               style={
                 Object {
                   "color": "#303030",
-                  "flex": 0,
                   "fontFamily": null,
                   "fontSize": 25.2,
                   "fontWeight": "700",


### PR DESCRIPTION
Patches a bunch of stuff that got missed in #133.

- fixes card sizing by removing flex all over and letting the images aspect ratio define card size.
- fixes image sometimes not filling parent due to minHeight on card and flex all over.
- **re-adds missing `isLiked` prop after error during previous merge conflict.**
- fixes stories not using images prop.
- adding missing states to some tests and stories.
- updates CardWrapper to match changes made to feed card down stream and swaps it into feed card as it's card component.

## Creator

- [x] Build relevant tests if any apply
- [x] Ensure there are no new warnings
- [x] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

