### PR TITLE
use in-app browser instead of linking

### DIFF
--- a/src/@ui/HTMLView/index.js
+++ b/src/@ui/HTMLView/index.js
@@ -1,6 +1,6 @@
 import React, { PureComponent, cloneElement, Children } from 'react';
 import PropTypes from 'prop-types';
-import { View, Text, Linking } from 'react-native';
+import { View, Text } from 'react-native';
 import { Parser, DomHandler } from 'htmlparser2';
 import { decodeHTML } from 'entities';
 import { BodyText, H1, H2, H3, H4, H5, H6, H7 } from '@ui/typography';
@@ -9,6 +9,7 @@ import ConnectedImage from '@ui/ConnectedImage';
 import Paragraph from '@ui/Paragraph';
 import BlockQuote from '@ui/BlockQuote';
 import BulletListItem from '@ui/BulletListItem';
+import WebBrowser from '@ui/WebBrowser';
 
 const LINE_BREAK = '\n';
 
@@ -58,7 +59,7 @@ export const defaultRenderer = (node, { children }) => {
     case 'li': return <BulletListItem>{wrapTextChildren(children)}</BulletListItem>;
     case 'a': {
       const url = node.attribs && node.attribs.href;
-      const onPress = () => Linking.openURL(decodeHTML(url));
+      const onPress = () => WebBrowser.openBrowserAsync(decodeHTML(url));
       if (url) {
         return (<ButtonLink onPress={onPress}>{children}</ButtonLink>);
       }

--- a/src/@ui/NativeWebRouter/Link.js
+++ b/src/@ui/NativeWebRouter/Link.js
@@ -1,7 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Touchable from '@ui/Touchable';
-import { Linking } from 'react-native';
+import WebBrowser from '@ui/WebBrowser';
+
 import { matchPath } from './';
 
 export const goBackTo = ({ to, history, replace = false }) => {
@@ -66,7 +67,7 @@ export default class Link extends Component {
 
     // handle web links
     if (to && to.indexOf('http') > -1) {
-      return Linking.openURL(to);
+      return WebBrowser.openBrowserAsync(to);
     }
 
     if (pop) {

--- a/src/@ui/WebBrowser/index.web.js
+++ b/src/@ui/WebBrowser/index.web.js
@@ -1,1 +1,5 @@
-export default () => {};
+import { Linking } from 'react-native';
+
+export default {
+  openBrowserAsync: Linking.openURL,
+};

--- a/src/give/Checkout/Failure.js
+++ b/src/give/Checkout/Failure.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import { Linking } from 'react-native';
 import styled from '@ui/styled';
 import PaddedView from '@ui/PaddedView';
 import Icon from '@ui/Icon';
 import { H3, H4, BodyText } from '@ui/typography';
 import { withTheme } from '@ui/theme';
 import { ButtonLink } from '@ui/Button';
+import WebBrowser from '@ui/WebBrowser';
 
-const contact = () => Linking.openURL('https://rock.newspring.cc/workflows/152?Topic=Stewardship');
+const contact = () => WebBrowser.openBrowserAsync('https://rock.newspring.cc/workflows/152?Topic=Stewardship');
 
 const BackgroundView = styled(({ theme }) => ({
   backgroundColor: theme.colors.background.paper,

--- a/src/give/ContributionHistory/ContributionHistoryList.js
+++ b/src/give/ContributionHistory/ContributionHistoryList.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import {
-  View, Linking,
+  View,
 } from 'react-native';
 import PropTypes from 'prop-types';
 import { groupBy, map } from 'lodash';
@@ -13,6 +13,7 @@ import { BodyText } from '@ui/typography';
 import { ButtonLink } from '@ui/Button';
 import Touchable from '@ui/Touchable';
 import LoginPromptCard from '@ui/LoginPromptCard';
+import WebBrowser from '@ui/WebBrowser';
 import ContributionHistoryHeader from './ContributionHistoryHeader';
 import ContributionHistoryFilter from './ContributionHistoryFilter';
 
@@ -104,7 +105,7 @@ class ContributionHistoryList extends PureComponent {
           <PaddedView>
             <BodyText>
               If you have any questions, please call our Finance Team at 864-965-9990 or
-              <ButtonLink onPress={() => Linking.openURL('https://newspring.cc/contact')}> contact us </ButtonLink>
+              <ButtonLink onPress={() => WebBrowser.openBrowserAsync('https://newspring.cc/contact')}> contact us </ButtonLink>
               and someone will be happy to assist you.
             </BodyText>
           </PaddedView>

--- a/src/give/ScheduleDetails/ScheduleTransactionHistory.js
+++ b/src/give/ScheduleDetails/ScheduleTransactionHistory.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Linking } from 'react-native';
+import { View } from 'react-native';
 import PropTypes from 'prop-types';
 import { BodyText } from '@ui/typography';
 import PaddedView from '@ui/PaddedView';
@@ -7,6 +7,7 @@ import Spacer from '@ui/Spacer';
 import { Link } from '@ui/NativeWebRouter';
 import { ButtonLink } from '@ui/Button';
 import HistoricalContributionCard from '@ui/HistoricalContributionCard';
+import WebBrowser from '@ui/WebBrowser';
 
 const ScheduleTransactionHistory = ({
   transactions = [],
@@ -19,7 +20,7 @@ const ScheduleTransactionHistory = ({
         <Spacer byHeight />
         <BodyText italic>
           If you have any questions, please call our Finance Team at 864-965-9990 or{' '}
-          <ButtonLink onPress={() => Linking.openURL('https://rock.newspring.cc/workflows/152?Topic=Stewardship')}>
+          <ButtonLink onPress={() => WebBrowser.openBrowserAsync('https://rock.newspring.cc/workflows/152?Topic=Stewardship')}>
             Contact Us
           </ButtonLink>
           {' '}and someone will be happy to assist you.

--- a/src/give/Success.js
+++ b/src/give/Success.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import { Linking } from 'react-native';
 import styled from '@ui/styled';
 import PaddedView from '@ui/PaddedView';
 import Icon from '@ui/Icon';
 import { H3, BodyText } from '@ui/typography';
 import { withTheme } from '@ui/theme';
 import { ButtonLink } from '@ui/Button';
+import WebBrowser from '@ui/WebBrowser';
 
-const contact = () => Linking.openURL('https://rock.newspring.cc/workflows/152?Topic=Stewardship');
+const contact = () => WebBrowser.openBrowserAsync('https://rock.newspring.cc/workflows/152?Topic=Stewardship');
 
 const BackgroundView = styled(({ theme }) => ({
   backgroundColor: theme.colors.background.paper,

--- a/src/group-finder/GroupSingle.js
+++ b/src/group-finder/GroupSingle.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Linking, ScrollView, View, Platform } from 'react-native';
+import { ScrollView, View, Platform } from 'react-native';
 import { compose, mapProps, pure } from 'recompose';
 
 import withGroupInfo from '@data/withGroupInfo';
@@ -19,6 +19,7 @@ import { Link } from '@ui/NativeWebRouter';
 import Settings from '@utils/Settings';
 import MediaQuery from '@ui/MediaQuery';
 import SecondaryNav, { Like, Share } from '@ui/SecondaryNav';
+import WebBrowser from '@ui/WebBrowser';
 
 import Map from './Map';
 
@@ -145,9 +146,9 @@ const GroupSingle = enhance(({
                 <CenteredSideBySideView>
                   <AdTitle>#TheseAreMyPeople</AdTitle>
                   {isLeader ? (
-                    <Button title="Manage" bordered onPress={() => Linking.openURL(`${rockUrl}page/521?GroupId=${entityId}&${loginParam}`)} />
+                    <Button title="Manage" bordered onPress={() => WebBrowser.openBrowserAsync(`${rockUrl}page/521?GroupId=${entityId}&${loginParam}`)} />
                   ) : (
-                    <Button title="Contact" bordered onPress={() => Linking.openURL(`${rockUrl}Workflows/304?Group=${guid}${loginParam}`)} />
+                    <Button title="Contact" bordered onPress={() => WebBrowser.openBrowserAsync(`${rockUrl}Workflows/304?Group=${guid}${loginParam}`)} />
                   )}
                 </CenteredSideBySideView>
               </PaddedView>

--- a/src/group-finder/NoResults.js
+++ b/src/group-finder/NoResults.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Linking } from 'react-native';
 import Card, { CardContent } from '@ui/Card';
 import { BodyText } from '@ui/typography';
 import { ButtonLink } from '@ui/Button';
 import styled from '@ui/styled';
 import PaddedView from '@ui/PaddedView';
+import WebBrowser from '@ui/WebBrowser';
 
 const StyledBodyText = styled({ textAlign: 'center' })(BodyText);
 
@@ -14,7 +14,7 @@ const AdUnit = () => (
       <PaddedView>
         <StyledBodyText italic>
           {'Unfortunately, we didn\'t find any groups matching your search. Gather some friends, and '}
-          <ButtonLink onPress={() => Linking.openURL('https://rock.newspring.cc/workflows/81')}>start your own group</ButtonLink>
+          <ButtonLink onPress={() => WebBrowser.openBrowserAsync('https://rock.newspring.cc/workflows/81')}>start your own group</ButtonLink>
           {' !'}
         </StyledBodyText>
       </PaddedView>

--- a/src/tabs/Discover/Feed.js
+++ b/src/tabs/Discover/Feed.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { compose, withProps } from 'recompose';
-import { View, Linking } from 'react-native';
+import { View } from 'react-native';
 import FeedView, { defaultFeedItemRenderer } from '@ui/FeedView';
 import { H5, BodyText } from '@ui/typography';
 import { ButtonLink } from '@ui/Button';
@@ -10,6 +10,7 @@ import ThumbnailCard from '@ui/ThumbnailCard';
 import { withRecentLikes } from '@data/likes';
 import withPromotions from '@data/withPromotions';
 import styled from '@ui/styled';
+import WebBrowser from '@ui/WebBrowser';
 
 const FeaturedCard = defaultFeedItemRenderer(FeedItemCard);
 
@@ -74,7 +75,7 @@ const Feed = enhance(({
 
                   return (
                     <BodyText key={x.id}>
-                      <ButtonLink onPress={() => Linking.openURL(x.meta.urlTitle)}>
+                      <ButtonLink onPress={() => WebBrowser.openBrowserAsync(x.meta.urlTitle)}>
                         {x.title}
                       </ButtonLink>
                       {delimeter}


### PR DESCRIPTION
Fixes #301 

Uses in-app browser instead of Linking in most places. Created a fallback on web that still uses `Linking`, which will open the link in a new tab.

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [x] Run `test` and make sure all tests pass
- [x] Review function and form on iOS
- [ ] Review function and form on Android
- [x] Review function and form on Web
- [x] Review new test logic

