### PR TITLE
Fixing eslint console.log warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-react": "7.4.0",
     "exp": "^49.2.2",
     "jest": "^21.2.1",
-    "jest-expo": "^25.0.0",
+    "jest-expo": "^25.1.0",
     "react-native-scripts": "^1.6.0",
     "react-native-storybook-loader": "^1.5.1",
     "react-test-renderer": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
       "<rootDir>/config/polyfills.js"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!((jest-)?react-native|rn-*|react-clone-referenced-element|expo(nent)?|@expo(nent)?/.*|react-navigation))"
+      "node_modules/(?!((jest-)?react-native|rn-*|react-clone-referenced-element|expo(nent)?|@expo(nent)?/.*|react-navigation|sentry-expo))"
     ],
     "collectCoverage": true,
     "testMatch": [

--- a/src/@ui/ImagePicker/index.js
+++ b/src/@ui/ImagePicker/index.js
@@ -4,6 +4,7 @@ import { compose, withProps, setPropTypes } from 'recompose';
 import { ReactNativeFile } from 'extract-files';
 import Touchable from '@ui/Touchable';
 import { connectActionSheet } from '@ui/ActionSheet';
+import sentry from '@utils/sentry';
 
 const ImagePicker = compose(
   setPropTypes({
@@ -45,7 +46,7 @@ const ImagePicker = compose(
 
           if (onSelectFile) onSelectFile(file);
         } catch (e) {
-          console.log('image error', e); // eslint-disable-line no-console
+          sentry.captureException(e);
         }
       });
     },

--- a/src/@ui/ImagePicker/index.js
+++ b/src/@ui/ImagePicker/index.js
@@ -45,7 +45,7 @@ const ImagePicker = compose(
 
           if (onSelectFile) onSelectFile(file);
         } catch (e) {
-          console.log('image error', e);
+          console.log('image error', e); // eslint-disable-line no-console
         }
       });
     },

--- a/src/@ui/forms/BillingAddressForm.js
+++ b/src/@ui/forms/BillingAddressForm.js
@@ -1,20 +1,18 @@
 import React from 'react';
-import {
-  View,
-} from 'react-native';
+import { View } from 'react-native';
 import PropTypes from 'prop-types';
 import { branch, renderComponent, compose, setPropTypes } from 'recompose';
 import get from 'lodash/get';
 import { withFormik } from 'formik';
 import Yup from 'yup';
+
 import withGive from '@data/withGive';
 import withCheckout from '@data/withCheckout';
 import { withRouter } from '@ui/NativeWebRouter';
 import PaddedView from '@ui/PaddedView';
 import TableView, { FormFields } from '@ui/TableView';
-
 import ActivityIndicator from '@ui/ActivityIndicator';
-
+import sentry from '@utils/sentry';
 import * as Inputs from '@ui/inputs';
 import Button from '@ui/Button';
 
@@ -186,8 +184,8 @@ const BillingAddressForm = compose(
         setSubmitting(false);
         if (props.navigateToOnComplete) props.history.push(props.navigateToOnComplete);
       } catch (e) {
-        // todo: If there's an error, we want to stay on this page and display it.
-        console.log(e);
+        // TODO: If there's an error, we want to stay on this page and display it.
+        sentry.captureException(e);
       }
     },
   }),

--- a/src/@ui/forms/ChangePasswordForm.js
+++ b/src/@ui/forms/ChangePasswordForm.js
@@ -11,6 +11,7 @@ import TableView from '@ui/TableView';
 import Button from '@ui/Button';
 import { H6 } from '@ui/typography';
 import styled from '@ui/styled';
+import sentry from '@utils/sentry';
 
 const Status = styled({ textAlign: 'center' })(H6);
 
@@ -28,7 +29,7 @@ const enhance = compose(
       props.onSubmit(values)
         .catch((...e) => {
           setStatus('Please make sure your password is correct and try again');
-          console.log('Change Password error', e); // eslint-disable-line
+          sentry.captureException(e);
           // todo: show server error messages
         })
         .then((...args) => {

--- a/src/@ui/forms/ForgotPasswordForm.js
+++ b/src/@ui/forms/ForgotPasswordForm.js
@@ -8,6 +8,7 @@ import Yup from 'yup';
 import withUser from '@data/withUser';
 import { Text as TextInput } from '@ui/inputs';
 import Button from '@ui/Button';
+import sentry from '@utils/sentry';
 
 import Status from './FormStatusText';
 
@@ -25,7 +26,7 @@ const enhance = compose(
     }) => {
       props.onSubmit(values)
         .catch((...e) => {
-          console.log('Forgot Password error', e); // eslint-disable-line
+          sentry.captureException(e);
           setStatus(null);
           setFieldError('email', 'Could not find your email'); // todo: show server error messages
         })

--- a/src/@ui/forms/PaymentConfirmationForm.js
+++ b/src/@ui/forms/PaymentConfirmationForm.js
@@ -27,6 +27,7 @@ import TableView, { Cell, Divider } from '@ui/TableView';
 import CashAmountIndicator from '@ui/CashAmountIndicator';
 import styled from '@ui/styled';
 import Icon from '@ui/Icon';
+import sentry from '@utils/sentry';
 
 const LargeCellText = styled(({ theme }) => ({
   flexGrow: 1,
@@ -251,7 +252,7 @@ const PaymentConfirmationForm = compose(
         if (props.onComplete) props.onComplete(null, true);
         return true;
       } catch (err) {
-        console.log('err', err); // eslint-disable-line no-console
+        sentry.captureException(err);
         props.setPaymentResult({
           error: err.message,
         });

--- a/src/@ui/forms/ProfileDetailsForm.js
+++ b/src/@ui/forms/ProfileDetailsForm.js
@@ -5,6 +5,7 @@ import { get } from 'lodash';
 import Yup from 'yup';
 import { withFormik } from 'formik';
 import moment from 'moment';
+
 import ActivityIndicator from '@ui/ActivityIndicator';
 import * as Inputs from '@ui/inputs';
 import { H6 } from '@ui/typography';
@@ -14,6 +15,7 @@ import PaddedView from '@ui/PaddedView';
 import withCampuses from '@data/withCampuses';
 import withUser from '@data/withUser';
 import Button from '@ui/Button';
+import sentry from '@utils/sentry';
 
 const Status = styled({ textAlign: 'center' })(H6);
 
@@ -188,7 +190,7 @@ const ProfileDetailsForm = compose(
       } catch (err) {
         // TODO: Add space for general errors
         // and set via setErrors
-        console.log(err);
+        sentry.captureException(err);
         // throw err;
         setStatus('There was an error updating your information. Please try again.');
       } finally {

--- a/src/@ui/forms/ResetPasswordForm.js
+++ b/src/@ui/forms/ResetPasswordForm.js
@@ -10,6 +10,8 @@ import Yup from 'yup';
 import withUser from '@data/withUser';
 import { Text as TextInput } from '@ui/inputs';
 import Button from '@ui/Button';
+import sentry from '@utils/sentry';
+
 import Status from './FormStatusText';
 
 const enhance = compose(
@@ -22,7 +24,7 @@ const enhance = compose(
     validationSchema: Yup.object().shape({
       password: Yup.string().required(),
       passwordConfirm: Yup.string().oneOf([Yup.ref('password'), null])
-        .required('Password confirm is required'),
+        .required('A password is required'),
     }),
     handleSubmit: async (values, {
       props, setFieldError, setSubmitting, setStatus,
@@ -30,7 +32,7 @@ const enhance = compose(
       props.resetPassword({ token: props.token, newPassword: values.password })
         .catch((...e) => {
           setStatus('There was an error resetting your password.');
-          console.log('Reset password error', e); // eslint-disable-line
+          sentry.captureException(e);
           setFieldError('password', true); // todo: show real error message from server
         })
         .then((...args) => {

--- a/src/@ui/forms/SavedPaymentReviewForm.js
+++ b/src/@ui/forms/SavedPaymentReviewForm.js
@@ -15,6 +15,7 @@ import Icon from '@ui/Icon';
 import last4 from '@utils/last4';
 import TableView, { Cell, Divider } from '@ui/TableView';
 import PaddedView from '@ui/PaddedView';
+import sentry from '@utils/sentry';
 
 const Row = styled({
   flexDirection: 'row',
@@ -201,7 +202,7 @@ const PaymentConfirmationForm = compose(
         });
         return true;
       } catch (err) {
-        console.log('err', err); // eslint-disable-line no-console
+        sentry.captureException(err);
         props.setPaymentResult({
           error: err.message,
         });

--- a/src/@ui/forms/UploadProfileImageForm/index.js
+++ b/src/@ui/forms/UploadProfileImageForm/index.js
@@ -1,8 +1,10 @@
 import { compose, withProps } from 'recompose';
+
 import Settings from '@utils/Settings';
 import ImagePicker from '@ui/ImagePicker';
 import withUser from '@data/withUser';
 import fetch from '@utils/fetch';
+import sentry from '@utils/sentry';
 
 const UploadProfileImageForm = compose(
   withUser,
@@ -30,7 +32,7 @@ const UploadProfileImageForm = compose(
 
         return true;
       } catch (err) {
-        console.log(err);
+        sentry.captureException(err);
         throw err;
       }
     },

--- a/src/give/ContributionHistory/ContributionHistoryFilter.js
+++ b/src/give/ContributionHistory/ContributionHistoryFilter.js
@@ -5,6 +5,7 @@ import { withFormik } from 'formik';
 import moment from 'moment';
 import Yup from 'yup';
 import { compose } from 'recompose';
+
 import { DateInput } from '@ui/inputs';
 import Button from '@ui/Button';
 import { H7 } from '@ui/typography';
@@ -14,6 +15,7 @@ import TableView, { Cell, CellText, CellIcon, Divider } from '@ui/TableView';
 import Chip, { ChipList } from '@ui/Chip';
 import { withTheme } from '@ui/theme';
 import PaddedView from '@ui/PaddedView';
+import sentry from '@utils/sentry';
 
 const StyledTableView = styled({ marginBottom: 0 })(TableView);
 
@@ -195,7 +197,7 @@ const enhance = compose(
         setSubmitting(false);
       } catch (e) {
         // TODO: If there's an error, we want to stay on this page and display it.
-        console.log(e);
+        sentry.captureException(e);
       }
     },
   }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6530,9 +6530,9 @@ jest-environment-node@^22.1.4:
     jest-mock "^22.1.0"
     jest-util "^22.1.4"
 
-jest-expo@^25.0.0:
-  version "25.0.0"
-  resolved "https://registry.yarnpkg.com/jest-expo/-/jest-expo-25.0.0.tgz#c17b77b66091aca174445405a19ce2ae88e27dd9"
+jest-expo@^25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/jest-expo/-/jest-expo-25.1.0.tgz#7f91d0c93f3dadaa8f45dab065d06bccd0519a8c"
   dependencies:
     babel-jest "^22.1.0"
     jest "^22.1.1"


### PR DESCRIPTION
Fixes eslint `console.log` warnings by pushing previously logged and likely to never be seen errors to Sentry. Also bumps `jest-expo` to latest version.

## Creator

- [x] Build relevant tests if any apply
- [x] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [x] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

