### PR TITLE
Tweak copy for iOS checkout

### DIFF
--- a/src/@ui/Meta/__tests__/__snapshots__/index.js.snap
+++ b/src/@ui/Meta/__tests__/__snapshots__/index.js.snap
@@ -75,7 +75,7 @@ Object {
       "name": "og:image",
     },
     Object {
-      "content": "http://beta.beta-my.newspring.cc",
+      "content": "http://localhost:3000",
       "name": "og:url",
     },
     Object {
@@ -191,7 +191,7 @@ Object {
       "name": "og:image",
     },
     Object {
-      "content": "http://beta.beta-my.newspring.cc",
+      "content": "http://localhost:3000",
       "name": "og:url",
     },
     Object {
@@ -285,7 +285,7 @@ Object {
       "name": "og:image",
     },
     Object {
-      "content": "http://beta.beta-my.newspring.cc",
+      "content": "http://localhost:3000",
       "name": "og:url",
     },
     Object {
@@ -379,7 +379,7 @@ Object {
       "name": "og:image",
     },
     Object {
-      "content": "http://beta.beta-my.newspring.cc",
+      "content": "http://localhost:3000",
       "name": "og:url",
     },
     Object {

--- a/src/@ui/Meta/__tests__/__snapshots__/index.js.snap
+++ b/src/@ui/Meta/__tests__/__snapshots__/index.js.snap
@@ -75,7 +75,7 @@ Object {
       "name": "og:image",
     },
     Object {
-      "content": "http://localhost:3000",
+      "content": "http://beta.beta-my.newspring.cc",
       "name": "og:url",
     },
     Object {
@@ -191,7 +191,7 @@ Object {
       "name": "og:image",
     },
     Object {
-      "content": "http://localhost:3000",
+      "content": "http://beta.beta-my.newspring.cc",
       "name": "og:url",
     },
     Object {
@@ -285,7 +285,7 @@ Object {
       "name": "og:image",
     },
     Object {
-      "content": "http://localhost:3000",
+      "content": "http://beta.beta-my.newspring.cc",
       "name": "og:url",
     },
     Object {
@@ -379,7 +379,7 @@ Object {
       "name": "og:image",
     },
     Object {
-      "content": "http://localhost:3000",
+      "content": "http://beta.beta-my.newspring.cc",
       "name": "og:url",
     },
     Object {

--- a/src/@ui/forms/PaymentConfirmationForm.js
+++ b/src/@ui/forms/PaymentConfirmationForm.js
@@ -152,7 +152,7 @@ export class PaymentConfirmationFormWithoutData extends PureComponent {
         {(Platform.OS === 'ios') ? (
           <PaddedView>
             <H7>
-              {'You\'ll be redirected to Safari to securely complete this contribution.'}
+              {'To finish giving, you\'ll be redirected to Safari to securely complete this contribution.'}
             </H7>
           </PaddedView>
         ) : null}
@@ -282,8 +282,8 @@ const PaymentConfirmationForm = compose(
     const text = `${verb} with ${name}`;
     const icon = (paymentMethod.paymentMethod || contributions.paymentMethod) === 'creditCard' ? 'credit' : 'bank';
     return {
-      submitButtonText: text,
-      submitButtonIcon: icon,
+      submitButtonText: Platform.OS === 'ios' ? 'Continue in Safari' : text,
+      submitButtonIcon: Platform.OS === 'ios' ? null : icon,
     };
   }),
 )(PaymentConfirmationFormWithoutData);

--- a/src/@ui/forms/__snapshots__/PaymentConfirmationForm.tests.js.snap
+++ b/src/@ui/forms/__snapshots__/PaymentConfirmationForm.tests.js.snap
@@ -327,7 +327,7 @@ exports[`The PaymentConfirmationForm component renders correctly 1`] = `
         }
       }
     >
-      You'll be redirected to Safari to securely complete this contribution.
+      To finish giving, you'll be redirected to Safari to securely complete this contribution.
     </Text>
   </View>
   <View
@@ -736,7 +736,7 @@ exports[`The PaymentConfirmationForm component shows a paying state 1`] = `
         }
       }
     >
-      You'll be redirected to Safari to securely complete this contribution.
+      To finish giving, you'll be redirected to Safari to securely complete this contribution.
     </Text>
   </View>
   <View
@@ -1267,7 +1267,7 @@ exports[`The PaymentConfirmationForm component shows a scheduled contribution 1`
         }
       }
     >
-      You'll be redirected to Safari to securely complete this contribution.
+      To finish giving, you'll be redirected to Safari to securely complete this contribution.
     </Text>
   </View>
   <View


### PR DESCRIPTION
Fixes #416 

Quick tweak to the copy on the contribution form on ios:

![image](https://user-images.githubusercontent.com/103927/38330682-dd8144f6-3816-11e8-9d16-f4165d6a7808.png)

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

