### PR TITLE
Performance: Splash Screen

### DIFF
--- a/app-config.js
+++ b/app-config.js
@@ -24,8 +24,9 @@ module.exports = env => ({
       ],
       icon: 'src/assets/icons/ios/icon-1024x1024.png',
       splash: {
-        backgroundColor: '#c7d4e0',
+        backgroundColor: '#D1DCE6',
       },
+      loadJSInBackgroundExperimental: true,
     },
     android: {
       package: 'cc.newspring.newspringapp',


### PR DESCRIPTION
This triggers a feature on ios that should improve loading times. Android has this feature enabled by default.

Also, @IsaacHardy ... could the color issue just have been "fixed", and splash screen backgroundColor can be the same between ios and android now? Not sure...

## Creator

- [x] Build relevant tests if any apply
- [x] Ensure there are no new warnings
- [x] Upload an animated GIF showcasing the solution (if it applies)
- [x] Set a relevant reviewer

## Reviewer

- [x] Run `test` and make sure all tests pass
- [x] Review function and form on iOS
- [x] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

