### PR TITLE
Performance: progressive image loading

### DIFF
--- a/src/@data/fragments.js
+++ b/src/@data/fragments.js
@@ -1,0 +1,23 @@
+import gql from 'graphql-tag';
+
+export const imageFragment = gql`
+  fragment ImageFragment on File {
+    fileName
+    fileType
+    fileLabel
+    url
+    size
+  }
+`;
+
+export const contentDataImagesFragment = gql`
+  fragment ContentDataImagesFragment on ContentData {
+    images(sizes: ["large", "medium"]) {
+      ...ImageFragment
+    }
+    thumbnailImage: images(sizes: ["xsmall"]) {
+      ...ImageFragment
+    }
+  }
+  ${imageFragment}
+`;

--- a/src/@data/likes/fragments.js
+++ b/src/@data/likes/fragments.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export const contentCard = gql`
   fragment ContentCard on Content {
@@ -13,12 +14,7 @@ export const contentCard = gql`
         urlTitle
       }
       content {
-        images(sizes: ["medium"]) {
-          url
-          label
-          fileLabel
-          id
-        }
+        ...ContentDataImagesFragment
       }
     }
     meta {
@@ -26,14 +22,10 @@ export const contentCard = gql`
     }
     content {
       isLiked
-      images(sizes: ["medium"]) {
-        url
-        label
-        fileLabel
-        id
-      }
+      ...ContentDataImagesFragment
     }
   }
+  ${contentDataImagesFragment}
 `;
 
 export const groupCard = gql`

--- a/src/@data/mediaPlayer/albumQuery.js
+++ b/src/@data/mediaPlayer/albumQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query getAlbum($id: ID!) {
@@ -22,13 +23,7 @@ export default gql`
             duration
             file: s3
           }
-          images(sizes: ["large", "medium", "small", "xsmall"]) {
-            fileName
-            fileType
-            fileLabel
-            size
-            url
-          }
+          ...ContentDataImagesFragment
           colors {
             value
             description
@@ -38,4 +33,5 @@ export default gql`
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/mediaPlayer/albumsQuery.js
+++ b/src/@data/mediaPlayer/albumsQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query getAlbums($limit: Int!, $skip: Int!) {
@@ -15,16 +16,12 @@ export default gql`
       }
       content {
         isLiked
-        images(sizes: ["large"]) {
-          fileName
-          fileType
-          fileLabel
-          url
-        }
+        ...ContentDataImagesFragment
         tracks {
           file: s3
         }
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withArticle/articleQuery.js
+++ b/src/@data/withArticle/articleQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query getArticle($id: ID!) {
@@ -22,14 +23,10 @@ export default gql`
             embedUrl
           }
           tags
-          images(sizes: ["large"]) {
-            fileName
-            fileType
-            fileLabel
-            url
-          }
+          ...ContentDataImagesFragment
         }
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withArticles/articlesQuery.js
+++ b/src/@data/withArticles/articlesQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query getArticles($limit: Int!, $skip: Int!) {
@@ -20,13 +21,9 @@ export default gql`
           book
           passage
         }
-        images(sizes: ["large"]) {
-          fileName
-          fileType
-          fileLabel
-          url
-        }
+        ...ContentDataImagesFragment
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withDevotional/devotionalQuery.js
+++ b/src/@data/withDevotional/devotionalQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query getDevotional($id: ID!) {
@@ -23,14 +24,10 @@ export default gql`
             book
             passage
           }
-          images(sizes: ["large"]) {
-            fileName
-            fileType
-            fileLabel
-            url
-          }
+          ...ContentDataImagesFragment
         }
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withDevotionals/devotionalsQuery.js
+++ b/src/@data/withDevotionals/devotionalsQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query getDevotionals($limit: Int!, $skip: Int!) {
@@ -17,13 +18,10 @@ export default gql`
       content {
         isLiked
         body
-        images(sizes: ["large"]) {
-          fileName
-          fileType
-          fileLabel
-          url
-        }
+        ...ContentDataImagesFragment
+
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withEvent/eventQuery.js
+++ b/src/@data/withEvent/eventQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query getContent($id: ID!) {
@@ -22,12 +23,7 @@ export default gql`
             embedUrl
           }
           tags
-          images(sizes: ["large"]) {
-            fileName
-            fileType
-            fileLabel
-            url
-          }
+          ...ContentDataImagesFragment
         }
       }
     }
@@ -36,4 +32,5 @@ export default gql`
       embedCode
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withHomeFeed/homeFeedQuery.js
+++ b/src/@data/withHomeFeed/homeFeedQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 const contentFragment = gql`
   fragment ContentForFeed on Content {
@@ -19,6 +20,7 @@ const contentFragment = gql`
       }
       content {
         isLight
+        ...ContentDataImagesFragment
         colors {
           value
           description
@@ -27,13 +29,7 @@ const contentFragment = gql`
     }
     content {
       isLiked
-      images(sizes: ["large"]) {
-        fileName
-        fileType
-        fileLabel
-        url
-        size
-      }
+      ...ContentDataImagesFragment
       isLight
       colors {
         value
@@ -41,6 +37,7 @@ const contentFragment = gql`
       }
     }
   }
+  ${contentDataImagesFragment}
 `;
 
 export default gql`

--- a/src/@data/withNewsStories/newsStoriesQuery.js
+++ b/src/@data/withNewsStories/newsStoriesQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query GetNews($limit: Int!, $skip: Int!) {
@@ -17,16 +18,12 @@ export default gql`
       content {
         isLiked
         body
-        images(sizes: ["large"]) {
-          fileName
-          fileType
-          fileLabel
-          url
-        }
+        ...ContentDataImagesFragment
         video {
           embedUrl
         }
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withNewsStory/newsStoryQuery.js
+++ b/src/@data/withNewsStory/newsStoryQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query getNews($id: ID!) {
@@ -22,14 +23,10 @@ export default gql`
             embedUrl
           }
           tags
-          images(sizes: ["large"]) {
-            fileName
-            fileType
-            fileLabel
-            url
-          }
+          ...ContentDataImagesFragment
         }
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withPromotions/promotionsQuery.js
+++ b/src/@data/withPromotions/promotionsQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query GetPromotions($setName: String!) {
@@ -12,13 +13,10 @@ export default gql`
         date
       }
       content {
-        images(sizes: ["large"]) {
-          fileName
-          fileLabel
-          url
-        }
+        ...ContentDataImagesFragment
         isLiked
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withRelatedContent/relatedContentQuery.js
+++ b/src/@data/withRelatedContent/relatedContentQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query GetRelatedContent($tags: [String], $includeChannels: [String], $limit: Int, $excludedIds: [String]) {
@@ -11,12 +12,7 @@ export default gql`
       parent {
         entryId: id
         content {
-          images(sizes: ["medium"]) {
-            url
-            label
-            fileLabel
-            id
-          }
+          ...ContentDataImagesFragment
         }
         meta {
           urlTitle
@@ -26,13 +22,9 @@ export default gql`
         urlTitle
       }
       content {
-        images(sizes: ["medium"]) {
-          url
-          label
-          fileLabel
-          id
-        }
+        ...ContentDataImagesFragment
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withSeries/seriesQuery.js
+++ b/src/@data/withSeries/seriesQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query getSeries($limit: Int!, $skip: Int!){
@@ -16,12 +17,7 @@ export default gql`
       }
       content {
         isLiked
-        images(sizes: ["large"]) {
-          fileName
-          fileType
-          fileLabel
-          url
-        }
+        ...ContentDataImagesFragment
         isLight
         colors {
           value
@@ -30,4 +26,5 @@ export default gql`
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withSeriesContent/seriesContentQuery.js
+++ b/src/@data/withSeriesContent/seriesContentQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query getSeriesSingle($id: ID!) {
@@ -20,12 +21,7 @@ export default gql`
           description
           tags
           isLight
-          images(sizes: ["large"]) {
-            fileName
-            fileType
-            fileLabel
-            url
-          }
+          ...ContentDataImagesFragment
           video {
             embedUrl
           }
@@ -52,4 +48,5 @@ export default gql`
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withSeriesSermon/seriesSermonQuery.js
+++ b/src/@data/withSeriesSermon/seriesSermonQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query GetSermonsFromSeries($id: ID!) {
@@ -18,12 +19,7 @@ export default gql`
                 value
                 description
               }
-              images(sizes: ["large", "medium"]) {
-                fileName
-                fileType
-                fileLabel
-                url
-              }
+              ...ContentDataImagesFragment
             }
             meta {
               urlTitle
@@ -43,4 +39,5 @@ export default gql`
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withSermon/sermonQuery.js
+++ b/src/@data/withSermon/sermonQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query getSermon($id: ID!) {
@@ -21,12 +22,7 @@ export default gql`
               value
               description
             }
-            images(sizes: ["large", "medium"]) {
-              fileName
-              fileType
-              fileLabel
-              url
-            }
+            ...ContentDataImagesFragment
           }
           children(channels: ["sermons"]) {
             id
@@ -62,4 +58,5 @@ export default gql`
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withStories/storiesQuery.js
+++ b/src/@data/withStories/storiesQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query getStories($limit: Int!, $skip: Int!) {
@@ -17,16 +18,12 @@ export default gql`
       content {
         isLiked
         body
-        images(sizes: ["large"]) {
-          fileName
-          fileType
-          fileLabel
-          url
-        }
+        ...ContentDataImagesFragment
         video {
           embedUrl
         }
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withStory/storyQuery.js
+++ b/src/@data/withStory/storyQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query getStory($id: ID!) {
@@ -22,14 +23,11 @@ export default gql`
             embedUrl
           }
           tags
-          images(sizes: ["large"]) {
-            fileName
-            fileType
-            fileLabel
-            url
-          }
+          ...ContentDataImagesFragment
+
         }
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withStudies/studiesQuery.js
+++ b/src/@data/withStudies/studiesQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query getSeries($limit: Int!, $skip: Int!){
@@ -16,12 +17,7 @@ export default gql`
       }
       content {
         isLiked
-        images(sizes: ["large"]) {
-          fileName
-          fileType
-          fileLabel
-          url
-        }
+        ...ContentDataImagesFragment
         isLight
         colors {
           value
@@ -30,4 +26,5 @@ export default gql`
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withStudy/studyQuery.js
+++ b/src/@data/withStudy/studyQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query GetSingleStudy($id: ID!) {
@@ -20,12 +21,7 @@ export default gql`
           description
           tags
           isLight
-          images(sizes: ["large"]) {
-            fileName
-            fileType
-            fileLabel
-            url
-          }
+          ...ContentDataImagesFragment
           video {
             embedUrl
           }
@@ -52,4 +48,5 @@ export default gql`
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withStudyEntries/studyEntriesQuery.js
+++ b/src/@data/withStudyEntries/studyEntriesQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query GetEntriesFromStudy($id: ID!) {
@@ -22,12 +23,7 @@ export default gql`
                 value
                 description
               }
-              images(sizes: ["large", "medium"]) {
-                fileName
-                fileType
-                fileLabel
-                url
-              }
+              ...ContentDataImagesFragment
             }
           }
           meta {
@@ -44,4 +40,5 @@ export default gql`
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withStudyEntry/studyEntryQuery.js
+++ b/src/@data/withStudyEntry/studyEntryQuery.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export default gql`
   query GetStudyEntry($id: ID!) {
@@ -28,12 +29,7 @@ export default gql`
               value
               description
             }
-            images(sizes: ["large", "medium"]) {
-              fileName
-              fileType
-              fileLabel
-              url
-            }
+            ...ContentDataImagesFragment
           }
           children(channels: ["study_entries"]) {
             id
@@ -53,13 +49,7 @@ export default gql`
             duration
             file: s3
           }
-          images(sizes: ["large", "medium"]) {
-            fileName
-            fileType
-            fileLabel
-            url
-            size
-          }
+          ...ContentDataImagesFragment
           scripture {
             book
             passage
@@ -74,4 +64,5 @@ export default gql`
       }
     }
   }
+  ${contentDataImagesFragment}
 `;

--- a/src/@data/withTaggedContent/index.js
+++ b/src/@data/withTaggedContent/index.js
@@ -1,6 +1,7 @@
 import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 import identifyCategory from '@data/utils/identifyCategory';
+import { contentDataImagesFragment } from '@data/fragments';
 
 export const QUERY = gql`
   query GetTaggedContent {
@@ -20,15 +21,11 @@ export const QUERY = gql`
       }
       content {
         isLiked
-        images(sizes: ["large"]) {
-          fileName
-          fileType
-          fileLabel
-          url
-        }
+        ...ContentDataImagesFragment
       }
     }
   }
+  ${contentDataImagesFragment}
 `;
 
 export default graphql(QUERY, {

--- a/src/@ui/AlbumView/__snapshots__/AlbumView.tests.js.snap
+++ b/src/@ui/AlbumView/__snapshots__/AlbumView.tests.js.snap
@@ -13,10 +13,26 @@ exports[`The AlbumView component should render 1`] = `
       Object {
         "aspectRatio": 1,
         "backgroundColor": "#858585",
+        "bottom": 0,
+        "left": 0,
+        "opacity": 0.4,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
         "width": "100%",
       }
     }
-  />
+  >
+    <View
+      style={
+        Object {
+          "aspectRatio": 1,
+          "backgroundColor": "#858585",
+          "width": "100%",
+        }
+      }
+    />
+  </View>
   <View
     style={
       Object {
@@ -32,10 +48,21 @@ exports[`The AlbumView component should render 1`] = `
         Object {
           "aspectRatio": 1,
           "backgroundColor": "#858585",
-          "width": "100%",
+          "position": "relative",
+          "width": "33%",
         }
       }
-    />
+    >
+      <View
+        style={
+          Object {
+            "aspectRatio": 1,
+            "backgroundColor": "#858585",
+            "width": "100%",
+          }
+        }
+      />
+    </View>
     <View
       style={
         Object {

--- a/src/@ui/AlbumView/index.js
+++ b/src/@ui/AlbumView/index.js
@@ -16,35 +16,22 @@ const InfoWrapper = styled({
   flexDirection: 'row', alignItems: 'stretch',
 }, 'AlbumView.InfoWrapper')(PaddedView);
 
-const AlbumArt = compose(
-  styled({
-    position: 'relative',
-    width: '33%',
-    aspectRatio: 1,
-    ...Platform.select({
-      web: {
-        height: 0,
-        paddingTop: '100%',
-      },
-    }),
-  }, 'AlbumView.AlbumArt'),
-  mapProps(({ style, ...otherProps }) => ({
-    containerStyle: style,
-    ...otherProps,
-  })),
-)(ProgressiveImage);
+const AlbumArt = styled({
+  position: 'relative',
+  width: '33%',
+  aspectRatio: 1,
+  ...Platform.select({
+    web: {
+      height: 0,
+      paddingTop: '100%',
+    },
+  }),
+}, 'AlbumView.AlbumArt')(ProgressiveImage);
 
-const BlurredImage = compose(
-  styled(({ theme }) => ({
-    ...StyleSheet.absoluteFillObject,
-    opacity: theme.alpha.low,
-  }), 'AlbumView.BlurredImage'),
-  mapProps(({ style, ...otherProps }) => ({
-    containerStyle: style,
-    blurRadius: 25,
-    ...otherProps,
-  })),
-)(ProgressiveImage);
+const BlurredImage = styled(({ theme }) => ({
+  ...StyleSheet.absoluteFillObject,
+  opacity: theme.alpha.low,
+}), 'AlbumView.BlurredImage')(ProgressiveImage);
 
 const TitleWrapper = styled({
   width: '66%',

--- a/src/@ui/AlbumView/index.js
+++ b/src/@ui/AlbumView/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { compose, pure, setPropTypes } from 'recompose';
+import { compose, pure, setPropTypes, mapProps } from 'recompose';
 import { View, Platform, StyleSheet } from 'react-native';
 import PaddedView from '@ui/PaddedView';
-import ConnectedImage from '@ui/ConnectedImage';
+import ProgressiveImage from '@ui/ProgressiveImage';
 import { H5, H7 } from '@ui/typography';
 import { withThemeMixin } from '@ui/theme';
 import styled from '@ui/styled';
@@ -16,21 +16,35 @@ const InfoWrapper = styled({
   flexDirection: 'row', alignItems: 'stretch',
 }, 'AlbumView.InfoWrapper')(PaddedView);
 
-const AlbumArt = styled({
-  width: '33%',
-  aspectRatio: 1,
-  ...Platform.select({
-    web: {
-      height: 0,
-      paddingTop: '100%',
-    },
-  }),
-}, 'AlbumView.AlbumArt')(ConnectedImage);
+const AlbumArt = compose(
+  styled({
+    position: 'relative',
+    width: '33%',
+    aspectRatio: 1,
+    ...Platform.select({
+      web: {
+        height: 0,
+        paddingTop: '100%',
+      },
+    }),
+  }, 'AlbumView.AlbumArt'),
+  mapProps(({ style, ...otherProps }) => ({
+    containerStyle: style,
+    ...otherProps,
+  })),
+)(ProgressiveImage);
 
-const BlurredImage = styled(({ theme }) => ({
-  ...StyleSheet.absoluteFillObject,
-  opacity: theme.alpha.low,
-}), 'AlbumView.BlurredImage')(ConnectedImage);
+const BlurredImage = compose(
+  styled(({ theme }) => ({
+    ...StyleSheet.absoluteFillObject,
+    opacity: theme.alpha.low,
+  }), 'AlbumView.BlurredImage'),
+  mapProps(({ style, ...otherProps }) => ({
+    containerStyle: style,
+    blurRadius: 25,
+    ...otherProps,
+  })),
+)(ProgressiveImage);
 
 const TitleWrapper = styled({
   width: '66%',
@@ -53,8 +67,8 @@ const enhance = compose(
   setPropTypes({
     title: PropTypes.string,
     artist: PropTypes.string,
-    blurredImage: ConnectedImage.propTypes.source,
-    albumImage: ConnectedImage.propTypes.source,
+    blurredImage: ProgressiveImage.propTypes.source,
+    albumImage: ProgressiveImage.propTypes.source,
     isLoading: PropTypes.bool,
   }),
 );

--- a/src/@ui/AlbumView/index.js
+++ b/src/@ui/AlbumView/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { compose, pure, setPropTypes, mapProps } from 'recompose';
+import { compose, pure, setPropTypes } from 'recompose';
 import { View, Platform, StyleSheet } from 'react-native';
 import PaddedView from '@ui/PaddedView';
 import ProgressiveImage from '@ui/ProgressiveImage';

--- a/src/@ui/Card/Image.js
+++ b/src/@ui/Card/Image.js
@@ -2,7 +2,7 @@ import { Platform } from 'react-native';
 import { compose } from 'recompose';
 
 import styled from '@ui/styled';
-import ConnectedImage from '@ui/ConnectedImage';
+import ProgressiveImage from '@ui/ProgressiveImage';
 import { getIsLoading } from '@ui/isLoading';
 
 const Image = compose(
@@ -10,7 +10,6 @@ const Image = compose(
   styled(({ theme }) => ({
     aspectRatio: 1,
     width: '100%',
-    resizeMode: 'cover',
     ...Platform.select({
       android: { // fixes android borderRadius overflow display issue
         borderTopRightRadius: theme.sizing.borderRadius,
@@ -23,8 +22,8 @@ const Image = compose(
       },
     }),
   }), 'Card.Image'),
-)(ConnectedImage);
+)(ProgressiveImage);
 
-Image.propTypes = ConnectedImage.propTypes;
+Image.propTypes = ProgressiveImage.propTypes;
 
 export default Image;

--- a/src/@ui/Card/__snapshots__/Card.tests.js.snap
+++ b/src/@ui/Card/__snapshots__/Card.tests.js.snap
@@ -177,7 +177,17 @@ exports[`the Card component should render 1`] = `
           "width": "100%",
         }
       }
-    />
+    >
+      <View
+        style={
+          Object {
+            "aspectRatio": 1,
+            "backgroundColor": "#dddddd",
+            "width": "100%",
+          }
+        }
+      />
+    </View>
     <View
       style={
         Object {

--- a/src/@ui/ConnectedImage/ConnectedImage.tests.js
+++ b/src/@ui/ConnectedImage/ConnectedImage.tests.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { ThemeProvider } from '@ui/theme';
 
 import ConnectedImage, {
   getCachedSources,
@@ -9,26 +10,30 @@ import ConnectedImage, {
 describe('the ConnectedImage component', () => {
   it('should render immediately with a network image with a known width and height', () => {
     const tree = renderer.create(
-      <ConnectedImage
-        source={{
-          uri: 'https://placeholdit.co/i/150x150?bg=eeeeee&fc=577084',
-          width: 150,
-          height: 150,
-        }}
-      />,
+      <ThemeProvider>
+        <ConnectedImage
+          source={{
+            uri: 'https://placeholdit.co/i/150x150?bg=eeeeee&fc=577084',
+            width: 150,
+            height: 150,
+          }}
+        />
+      </ThemeProvider>,
     );
     expect(tree).toMatchSnapshot();
   });
   it('should maintain aspect ratio', () => {
     const tree = renderer.create(
-      <ConnectedImage
-        source={{
-          uri: 'https://placeholdit.co/i/150x150?bg=eeeeee&fc=577084',
-          width: 150,
-          height: 150,
-        }}
-        maintainAspectRatio
-      />,
+      <ThemeProvider>
+        <ConnectedImage
+          source={{
+            uri: 'https://placeholdit.co/i/150x150?bg=eeeeee&fc=577084',
+            width: 150,
+            height: 150,
+          }}
+          maintainAspectRatio
+        />
+      </ThemeProvider>,
     );
     expect(tree).toMatchSnapshot();
   });

--- a/src/@ui/ConnectedImage/__snapshots__/ConnectedImage.tests.js.snap
+++ b/src/@ui/ConnectedImage/__snapshots__/ConnectedImage.tests.js.snap
@@ -2,7 +2,9 @@
 
 exports[`the ConnectedImage component should maintain aspect ratio 1`] = `
 <Image
+  collapsable={undefined}
   maintainAspectRatio={true}
+  onLoad={[Function]}
   source={
     Array [
       Object {
@@ -13,19 +15,20 @@ exports[`the ConnectedImage component should maintain aspect ratio 1`] = `
     ]
   }
   style={
-    Array [
-      Object {
-        "aspectRatio": 1,
-      },
-      undefined,
-    ]
+    Object {
+      "aspectRatio": 1,
+      "backgroundColor": "#dddddd",
+      "opacity": 0,
+    }
   }
 />
 `;
 
 exports[`the ConnectedImage component should render immediately with a network image with a known width and height 1`] = `
 <Image
+  collapsable={undefined}
   maintainAspectRatio={false}
+  onLoad={[Function]}
   source={
     Array [
       Object {
@@ -36,10 +39,10 @@ exports[`the ConnectedImage component should render immediately with a network i
     ]
   }
   style={
-    Array [
-      Object {},
-      undefined,
-    ]
+    Object {
+      "backgroundColor": "#dddddd",
+      "opacity": 0,
+    }
   }
 />
 `;

--- a/src/@ui/ConnectedImage/index.js
+++ b/src/@ui/ConnectedImage/index.js
@@ -1,8 +1,9 @@
 import React, { PureComponent } from 'react';
-import { Platform, Image } from 'react-native';
+import { Animated, Platform, Image } from 'react-native';
 import PropTypes from 'prop-types';
 import { every } from 'lodash';
 import makeCancelable from '@utils/makeCancelable';
+import styled from '@ui/styled';
 
 import SkeletonImage from './SkeletonImage';
 
@@ -53,6 +54,10 @@ export const updateCache = sources => Promise.all(getCachedSources(sources).map(
   });
 }));
 
+const withBackgroundColor = styled(({ theme }) => ({
+  backgroundColor: theme.colors.background.inactive,
+}));
+
 class ConnectedImage extends PureComponent {
   static propTypes = {
     source: PropTypes.oneOfType([
@@ -62,11 +67,12 @@ class ConnectedImage extends PureComponent {
     ImageComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     maintainAspectRatio: PropTypes.bool,
     isLoading: PropTypes.bool,
+    onLoad: PropTypes.func,
     style: PropTypes.any, // eslint-disable-line
   }
 
   static defaultProps = {
-    ImageComponent: Image,
+    ImageComponent: Animated.Image,
     maintainAspectRatio: false,
   }
 
@@ -79,6 +85,14 @@ class ConnectedImage extends PureComponent {
 
   componentWillUnmount() {
     if (this.cacheUpdater) this.cacheUpdater.cancel();
+  }
+
+  onLoad = (...args) => {
+    Animated.timing(this.imageOpacity, {
+      toValue: 1,
+      duration: 250,
+    }).start();
+    if (this.props.onLoad) this.props.onLoad(...args);
   }
 
   get aspectRatio() {
@@ -100,6 +114,8 @@ class ConnectedImage extends PureComponent {
   get isLoading() {
     return this.props.isLoading || !every(this.state.source, image => image.width && image.height);
   }
+
+  imageOpacity = new Animated.Value(0);
 
   updateCache(sources) {
     this.cacheUpdater = makeCancelable(updateCache(sources));
@@ -130,7 +146,7 @@ class ConnectedImage extends PureComponent {
     }
 
     const {
-      ImageComponent = Image, style, isLoading, ...otherProps
+      ImageComponent = Animated.Image, style, isLoading, ...otherProps
     } = this.props;
 
     return (
@@ -138,11 +154,14 @@ class ConnectedImage extends PureComponent {
         <ImageComponent
           {...otherProps}
           source={source}
-          style={[this.aspectRatio, style]}
+          onLoad={this.onLoad}
+          style={[this.aspectRatio, { opacity: this.imageOpacity }, style]}
         />
       </SkeletonImage>
     );
   }
 }
 
-export default ConnectedImage;
+const enhanced = withBackgroundColor(ConnectedImage);
+enhanced.propTypes = ConnectedImage.propTypes;
+export default enhanced;

--- a/src/@ui/ConnectedImage/index.js
+++ b/src/@ui/ConnectedImage/index.js
@@ -135,7 +135,11 @@ class ConnectedImage extends PureComponent {
 
     return (
       <SkeletonImage onReady={!this.isLoading}>
-        <ImageComponent {...otherProps} source={source} style={[this.aspectRatio, style]} />
+        <ImageComponent
+          {...otherProps}
+          source={source}
+          style={[this.aspectRatio, style]}
+        />
       </SkeletonImage>
     );
   }

--- a/src/@ui/ContentView/Media/ImageHeader.js
+++ b/src/@ui/ContentView/Media/ImageHeader.js
@@ -1,36 +1,24 @@
 import React from 'react';
 import { compose, pure, setPropTypes } from 'recompose';
-import { Platform } from 'react-native';
 import PropTypes from 'prop-types';
 
-import ConnectedImage from '@ui/ConnectedImage';
 import GradientOverlayImage from '@ui/GradientOverlayImage';
-import styled from '@ui/styled';
+import ProgressiveImage from '@ui/ProgressiveImage';
 
 const enhance = compose(
   pure,
   setPropTypes({
     images: PropTypes.any, // eslint-disable-line
+    thumbnail:  PropTypes.any, // eslint-disable-line
     imageOverlayColor: PropTypes.string,
   }),
 );
 
-const StyledImage = styled({
-  width: '100%',
-  aspectRatio: 1,
-  resizeMode: 'cover',
-  ...Platform.select({
-    web: {
-      height: 0,
-      paddingTop: '50%',
-    },
-  }),
-})(ConnectedImage);
-
-const ImageHeader = enhance(({ images, imageOverlayColor }) => (
+const ImageHeader = enhance(({ images, thumbnail, imageOverlayColor }) => (
   <GradientOverlayImage
-    imageComponent={StyledImage}
+    ImageComponent={ProgressiveImage}
     source={images}
+    thumbnail={thumbnail}
     overlayColor={imageOverlayColor}
   />
 ));

--- a/src/@ui/ContentView/__snapshots__/ContentView.tests.js.snap
+++ b/src/@ui/ContentView/__snapshots__/ContentView.tests.js.snap
@@ -119,60 +119,14 @@ exports[`the ContentView component renders 1`] = `
 exports[`the ContentView component renders with images 1`] = `
 <View>
   <View
-    imageComponent={[Function]}
+    style={
+      Object {
+        "aspectRatio": 1,
+        "width": "100%",
+      }
+    }
   >
-    <Image
-      maintainAspectRatio={false}
-      source={
-        Array [
-          Object {
-            "height": 400,
-            "uri": "https://picsum.photos/600/400/?random",
-            "width": 600,
-          },
-          Object {
-            "height": 400,
-            "uri": "https://picsum.photos/600/400/?random",
-            "width": 600,
-          },
-        ]
-      }
-      style={
-        Array [
-          Object {},
-          Object {
-            "aspectRatio": 1,
-            "resizeMode": "cover",
-            "width": "100%",
-          },
-        ]
-      }
-    />
-    <ExponentLinearGradient
-      colors={
-        Array [
-          16416882,
-          4294606962,
-        ]
-      }
-      endPoint={
-        Array [
-          0,
-          1,
-        ]
-      }
-      locations={
-        Array [
-          0.3,
-          1,
-        ]
-      }
-      startPoint={
-        Array [
-          0,
-          0,
-        ]
-      }
+    <View
       style={
         Object {
           "bottom": 0,
@@ -182,7 +136,86 @@ exports[`the ContentView component renders with images 1`] = `
           "top": 0,
         }
       }
-    />
+    >
+      <View
+        style={
+          Object {
+            "aspectRatio": 1,
+            "backgroundColor": "#dddddd",
+            "width": "100%",
+          }
+        }
+      >
+        <Image
+          collapsable={undefined}
+          maintainAspectRatio={false}
+          onLoad={[Function]}
+          source={
+            Array [
+              Object {
+                "height": 400,
+                "uri": "https://picsum.photos/600/400/?random",
+                "width": 600,
+              },
+              Object {
+                "height": 400,
+                "uri": "https://picsum.photos/600/400/?random",
+                "width": 600,
+              },
+            ]
+          }
+          style={
+            Object {
+              "backgroundColor": "#dddddd",
+              "bottom": 0,
+              "height": "100%",
+              "left": 0,
+              "opacity": 0,
+              "position": "absolute",
+              "resizeMode": "cover",
+              "right": 0,
+              "top": 0,
+              "width": "100%",
+            }
+          }
+        />
+      </View>
+      <ExponentLinearGradient
+        colors={
+          Array [
+            16416882,
+            4294606962,
+          ]
+        }
+        endPoint={
+          Array [
+            0,
+            1,
+          ]
+        }
+        locations={
+          Array [
+            0.3,
+            1,
+          ]
+        }
+        startPoint={
+          Array [
+            0,
+            0,
+          ]
+        }
+        style={
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      />
+    </View>
   </View>
   <View
     style={

--- a/src/@ui/ContentView/index.js
+++ b/src/@ui/ContentView/index.js
@@ -38,6 +38,11 @@ const enhance = compose(
         url: PropTypes.string,
       }),
     ),
+    thumbnail: PropTypes.arrayOf(
+      PropTypes.shape({
+        url: PropTypes.string,
+      }),
+    ),
     imageOverlayColor: PropTypes.string,
   }),
 );
@@ -46,18 +51,28 @@ const ContentWrapper = styled(({ theme }) => ({
   padding: theme.sizing.baseUnit,
 }))(View);
 
-const renderHeader = (video, images = [], imageOverlayColor) => {
+const renderHeader = ({
+  video, images = [], thumbnailImage, imageOverlayColor,
+}) => {
   let headerType = null;
   if (video && video.embedUrl) {
     headerType = <VideoHeader source={video} />;
   } else if (images && images.length) {
-    headerType = <ImageHeader images={images} imageOverlayColor={imageOverlayColor} />;
+    headerType = (
+      <ImageHeader
+        images={images}
+        thumbnail={thumbnailImage}
+        imageOverlayColor={imageOverlayColor}
+      />
+    );
   }
 
   return headerType;
 };
 
-const renderAudioBar = (contentId, title, audio, seriesImages, seriesColors) => {
+const renderAudioBar = ({
+  contentId, title, audio, seriesImages, seriesColors,
+}) => {
   let audioComponent = null;
   if (audio && audio.length) {
     const track = {
@@ -87,6 +102,7 @@ const ContentView = enhance(
     contentId,
     video,
     images = [],
+    thumbnailImage,
     seriesImages = [],
     seriesColors = [],
     imageOverlayColor = '',
@@ -95,8 +111,8 @@ const ContentView = enhance(
     children,
   }) => (
     <View>
-      {renderHeader(video, images, imageOverlayColor)}
-      {renderAudioBar(contentId, title, audio, seriesImages, seriesColors)}
+      {renderHeader({ video, images, thumbnailImage, imageOverlayColor })}
+      {renderAudioBar({ contentId, title, audio, seriesImages, seriesColors })}
       <ContentWrapper>{children}</ContentWrapper>
     </View>
   ),

--- a/src/@ui/ContentView/index.js
+++ b/src/@ui/ContentView/index.js
@@ -111,8 +111,12 @@ const ContentView = enhance(
     children,
   }) => (
     <View>
-      {renderHeader({ video, images, thumbnailImage, imageOverlayColor })}
-      {renderAudioBar({ contentId, title, audio, seriesImages, seriesColors })}
+      {renderHeader({
+ video, images, thumbnailImage, imageOverlayColor,
+})}
+      {renderAudioBar({
+ contentId, title, audio, seriesImages, seriesColors,
+})}
       <ContentWrapper>{children}</ContentWrapper>
     </View>
   ),

--- a/src/@ui/FeedItemCard/__snapshots__/FeedItemCard.tests.js.snap
+++ b/src/@ui/FeedItemCard/__snapshots__/FeedItemCard.tests.js.snap
@@ -28,54 +28,15 @@ exports[`the FeedItemCard component should accept a different backgroundColor 1`
       }
     }
   >
-    <View>
-      <Image
-        maintainAspectRatio={false}
-        source={
-          Array [
-            Object {
-              "height": 400,
-              "uri": "https://picsum.photos/600/400/?random",
-              "width": 600,
-            },
-          ]
+    <View
+      style={
+        Object {
+          "aspectRatio": 1,
+          "width": "100%",
         }
-        style={
-          Array [
-            Object {},
-            Object {
-              "aspectRatio": 1,
-              "resizeMode": "cover",
-              "width": "100%",
-            },
-          ]
-        }
-      />
-      <ExponentLinearGradient
-        colors={
-          Array [
-            16416882,
-            4294606962,
-          ]
-        }
-        endPoint={
-          Array [
-            0,
-            1,
-          ]
-        }
-        locations={
-          Array [
-            0.3,
-            1,
-          ]
-        }
-        startPoint={
-          Array [
-            0,
-            0,
-          ]
-        }
+      }
+    >
+      <View
         style={
           Object {
             "bottom": 0,
@@ -85,7 +46,81 @@ exports[`the FeedItemCard component should accept a different backgroundColor 1`
             "top": 0,
           }
         }
-      />
+      >
+        <View
+          style={
+            Object {
+              "aspectRatio": 1,
+              "backgroundColor": "#dddddd",
+              "width": "100%",
+            }
+          }
+        >
+          <Image
+            collapsable={undefined}
+            maintainAspectRatio={false}
+            onLoad={[Function]}
+            source={
+              Array [
+                Object {
+                  "height": 400,
+                  "uri": "https://picsum.photos/600/400/?random",
+                  "width": 600,
+                },
+              ]
+            }
+            style={
+              Object {
+                "backgroundColor": "#dddddd",
+                "bottom": 0,
+                "height": "100%",
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "resizeMode": "cover",
+                "right": 0,
+                "top": 0,
+                "width": "100%",
+              }
+            }
+          />
+        </View>
+        <ExponentLinearGradient
+          colors={
+            Array [
+              16416882,
+              4294606962,
+            ]
+          }
+          endPoint={
+            Array [
+              0,
+              1,
+            ]
+          }
+          locations={
+            Array [
+              0.3,
+              1,
+            ]
+          }
+          startPoint={
+            Array [
+              0,
+              0,
+            ]
+          }
+          style={
+            Object {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+        />
+      </View>
     </View>
     <View
       style={
@@ -245,29 +280,64 @@ exports[`the FeedItemCard component should accept and render passed in styles 1`
       }
     }
   >
-    <View>
-      <Image
-        maintainAspectRatio={false}
-        source={
-          Array [
-            Object {
-              "height": 400,
-              "uri": "https://picsum.photos/600/400/?random",
-              "width": 600,
-            },
-          ]
+    <View
+      style={
+        Object {
+          "aspectRatio": 1,
+          "width": "100%",
         }
+      }
+    >
+      <View
         style={
-          Array [
-            Object {},
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      >
+        <View
+          style={
             Object {
               "aspectRatio": 1,
-              "resizeMode": "cover",
+              "backgroundColor": "#dddddd",
               "width": "100%",
-            },
-          ]
-        }
-      />
+            }
+          }
+        >
+          <Image
+            collapsable={undefined}
+            maintainAspectRatio={false}
+            onLoad={[Function]}
+            source={
+              Array [
+                Object {
+                  "height": 400,
+                  "uri": "https://picsum.photos/600/400/?random",
+                  "width": 600,
+                },
+              ]
+            }
+            style={
+              Object {
+                "backgroundColor": "#dddddd",
+                "bottom": 0,
+                "height": "100%",
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "resizeMode": "cover",
+                "right": 0,
+                "top": 0,
+                "width": "100%",
+              }
+            }
+          />
+        </View>
+      </View>
     </View>
     <View
       style={
@@ -425,29 +495,64 @@ exports[`the FeedItemCard component should render 1`] = `
       }
     }
   >
-    <View>
-      <Image
-        maintainAspectRatio={false}
-        source={
-          Array [
-            Object {
-              "height": 400,
-              "uri": "https://picsum.photos/600/400/?random",
-              "width": 600,
-            },
-          ]
+    <View
+      style={
+        Object {
+          "aspectRatio": 1,
+          "width": "100%",
         }
+      }
+    >
+      <View
         style={
-          Array [
-            Object {},
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      >
+        <View
+          style={
             Object {
               "aspectRatio": 1,
-              "resizeMode": "cover",
+              "backgroundColor": "#dddddd",
               "width": "100%",
-            },
-          ]
-        }
-      />
+            }
+          }
+        >
+          <Image
+            collapsable={undefined}
+            maintainAspectRatio={false}
+            onLoad={[Function]}
+            source={
+              Array [
+                Object {
+                  "height": 400,
+                  "uri": "https://picsum.photos/600/400/?random",
+                  "width": 600,
+                },
+              ]
+            }
+            style={
+              Object {
+                "backgroundColor": "#dddddd",
+                "bottom": 0,
+                "height": "100%",
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "resizeMode": "cover",
+                "right": 0,
+                "top": 0,
+                "width": "100%",
+              }
+            }
+          />
+        </View>
+      </View>
     </View>
     <View
       style={
@@ -605,29 +710,64 @@ exports[`the FeedItemCard component should render as liked 1`] = `
       }
     }
   >
-    <View>
-      <Image
-        maintainAspectRatio={false}
-        source={
-          Array [
-            Object {
-              "height": 400,
-              "uri": "https://picsum.photos/600/400/?random",
-              "width": 600,
-            },
-          ]
+    <View
+      style={
+        Object {
+          "aspectRatio": 1,
+          "width": "100%",
         }
+      }
+    >
+      <View
         style={
-          Array [
-            Object {},
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      >
+        <View
+          style={
             Object {
               "aspectRatio": 1,
-              "resizeMode": "cover",
+              "backgroundColor": "#dddddd",
               "width": "100%",
-            },
-          ]
-        }
-      />
+            }
+          }
+        >
+          <Image
+            collapsable={undefined}
+            maintainAspectRatio={false}
+            onLoad={[Function]}
+            source={
+              Array [
+                Object {
+                  "height": 400,
+                  "uri": "https://picsum.photos/600/400/?random",
+                  "width": 600,
+                },
+              ]
+            }
+            style={
+              Object {
+                "backgroundColor": "#dddddd",
+                "bottom": 0,
+                "height": "100%",
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "resizeMode": "cover",
+                "right": 0,
+                "top": 0,
+                "width": "100%",
+              }
+            }
+          />
+        </View>
+      </View>
     </View>
     <View
       style={
@@ -785,29 +925,64 @@ exports[`the FeedItemCard component should render text correctly with isLight 1`
       }
     }
   >
-    <View>
-      <Image
-        maintainAspectRatio={false}
-        source={
-          Array [
-            Object {
-              "height": 400,
-              "uri": "https://picsum.photos/600/400/?random",
-              "width": 600,
-            },
-          ]
+    <View
+      style={
+        Object {
+          "aspectRatio": 1,
+          "width": "100%",
         }
+      }
+    >
+      <View
         style={
-          Array [
-            Object {},
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      >
+        <View
+          style={
             Object {
               "aspectRatio": 1,
-              "resizeMode": "cover",
+              "backgroundColor": "#dddddd",
               "width": "100%",
-            },
-          ]
-        }
-      />
+            }
+          }
+        >
+          <Image
+            collapsable={undefined}
+            maintainAspectRatio={false}
+            onLoad={[Function]}
+            source={
+              Array [
+                Object {
+                  "height": 400,
+                  "uri": "https://picsum.photos/600/400/?random",
+                  "width": 600,
+                },
+              ]
+            }
+            style={
+              Object {
+                "backgroundColor": "#dddddd",
+                "bottom": 0,
+                "height": "100%",
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "resizeMode": "cover",
+                "right": 0,
+                "top": 0,
+                "width": "100%",
+              }
+            }
+          />
+        </View>
+      </View>
     </View>
     <View
       style={
@@ -965,29 +1140,64 @@ exports[`the FeedItemCard component should render with inverted (light) font col
       }
     }
   >
-    <View>
-      <Image
-        maintainAspectRatio={false}
-        source={
-          Array [
-            Object {
-              "height": 400,
-              "uri": "https://picsum.photos/600/400/?random",
-              "width": 600,
-            },
-          ]
+    <View
+      style={
+        Object {
+          "aspectRatio": 1,
+          "width": "100%",
         }
+      }
+    >
+      <View
         style={
-          Array [
-            Object {},
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      >
+        <View
+          style={
             Object {
               "aspectRatio": 1,
-              "resizeMode": "cover",
+              "backgroundColor": "#858585",
               "width": "100%",
-            },
-          ]
-        }
-      />
+            }
+          }
+        >
+          <Image
+            collapsable={undefined}
+            maintainAspectRatio={false}
+            onLoad={[Function]}
+            source={
+              Array [
+                Object {
+                  "height": 400,
+                  "uri": "https://picsum.photos/600/400/?random",
+                  "width": 600,
+                },
+              ]
+            }
+            style={
+              Object {
+                "backgroundColor": "#858585",
+                "bottom": 0,
+                "height": "100%",
+                "left": 0,
+                "opacity": 0,
+                "position": "absolute",
+                "resizeMode": "cover",
+                "right": 0,
+                "top": 0,
+                "width": "100%",
+              }
+            }
+          />
+        </View>
+      </View>
     </View>
     <View
       style={

--- a/src/@ui/FeedItemCard/index.js
+++ b/src/@ui/FeedItemCard/index.js
@@ -10,10 +10,22 @@ import GradientOverlayImage from '@ui/GradientOverlayImage';
 import Card, { CardContent, CardActions } from '@ui/Card';
 import { H4 } from '@ui/typography';
 import styled from '@ui/styled';
+import ProgressiveImage from '@ui/ProgressiveImage';
 
 import LikeButton from './LikeButton';
 
 const StyledCardContent = styled({ paddingBottom: 0 })(CardContent);
+
+const sourcePropType = PropTypes.oneOfType([
+  PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      value: PropTypes.string,
+      description: PropTypes.string,
+    }),
+  ),
+  PropTypes.string,
+]);
 
 const enhance = compose(
   pure,
@@ -26,16 +38,8 @@ const enhance = compose(
   withTheme(),
   setPropTypes({
     title: PropTypes.string.isRequired,
-    images: PropTypes.oneOfType([
-      PropTypes.arrayOf(
-        PropTypes.shape({
-          id: PropTypes.number,
-          value: PropTypes.string,
-          description: PropTypes.string,
-        }),
-      ),
-      PropTypes.string,
-    ]),
+    images: sourcePropType,
+    thumbnail: sourcePropType,
     category: PropTypes.string.isRequired,
     isLoading: PropTypes.bool,
     isLiked: PropTypes.bool,
@@ -47,10 +51,24 @@ const enhance = compose(
 
 const FeedItemCard = enhance(
   ({
-    images, title, category, isLoading, isLiked, backgroundColor, theme, id, ...otherProps
+    images,
+    thumbnail,
+    title,
+    category,
+    isLoading,
+    isLiked,
+    backgroundColor,
+    theme,
+    id,
+    ...otherProps
   }) => (
     <Card isLoading={isLoading} cardColor={backgroundColor} {...otherProps}>
-      <GradientOverlayImage source={images} overlayColor={backgroundColor} />
+      <GradientOverlayImage
+        ImageComponent={ProgressiveImage}
+        source={images}
+        thumbnail={thumbnail}
+        overlayColor={backgroundColor}
+      />
       <StyledCardContent>
         <H4>{startCase(toLower(title))}</H4>
       </StyledCardContent>

--- a/src/@ui/FeedView/__tests__/__snapshots__/FeedView.tests.js.snap
+++ b/src/@ui/FeedView/__tests__/__snapshots__/FeedView.tests.js.snap
@@ -118,29 +118,85 @@ exports[`The FeedView component renders correctly 1`] = `
             }
           }
         >
-          <View>
-            <Image
-              maintainAspectRatio={false}
-              source={
-                Array [
-                  Object {
-                    "height": 400,
-                    "uri": "https://picsum.photos/600/400/?random",
-                    "width": 600,
-                  },
-                ]
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "width": "100%",
               }
+            }
+          >
+            <View
               style={
-                Array [
-                  Object {},
+                Object {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <View
+                style={
                   Object {
                     "aspectRatio": 1,
-                    "resizeMode": "cover",
+                    "backgroundColor": "#dddddd",
                     "width": "100%",
-                  },
-                ]
-              }
-            />
+                  }
+                }
+              >
+                <Image
+                  blurRadius={2}
+                  collapsable={undefined}
+                  maintainAspectRatio={false}
+                  onLoad={[Function]}
+                  source={Array []}
+                  style={
+                    Object {
+                      "backgroundColor": "#dddddd",
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "resizeMode": "cover",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <Image
+                  collapsable={undefined}
+                  maintainAspectRatio={false}
+                  onLoad={[Function]}
+                  source={
+                    Array [
+                      Object {
+                        "height": 400,
+                        "uri": "https://picsum.photos/600/400/?random",
+                        "width": 600,
+                      },
+                    ]
+                  }
+                  style={
+                    Object {
+                      "backgroundColor": "#dddddd",
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "resizeMode": "cover",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+              </View>
+            </View>
           </View>
           <View
             style={
@@ -314,54 +370,15 @@ exports[`The FeedView component renders correctly 1`] = `
             }
           }
         >
-          <View>
-            <Image
-              maintainAspectRatio={false}
-              source={
-                Array [
-                  Object {
-                    "height": 400,
-                    "uri": "https://picsum.photos/600/400/?random",
-                    "width": 600,
-                  },
-                ]
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "width": "100%",
               }
-              style={
-                Array [
-                  Object {},
-                  Object {
-                    "aspectRatio": 1,
-                    "resizeMode": "cover",
-                    "width": "100%",
-                  },
-                ]
-              }
-            />
-            <ExponentLinearGradient
-              colors={
-                Array [
-                  5783656,
-                  4283973736,
-                ]
-              }
-              endPoint={
-                Array [
-                  0,
-                  1,
-                ]
-              }
-              locations={
-                Array [
-                  0.3,
-                  1,
-                ]
-              }
-              startPoint={
-                Array [
-                  0,
-                  0,
-                ]
-              }
+            }
+          >
+            <View
               style={
                 Object {
                   "bottom": 0,
@@ -371,7 +388,102 @@ exports[`The FeedView component renders correctly 1`] = `
                   "top": 0,
                 }
               }
-            />
+            >
+              <View
+                style={
+                  Object {
+                    "aspectRatio": 1,
+                    "backgroundColor": "#dddddd",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  blurRadius={2}
+                  collapsable={undefined}
+                  maintainAspectRatio={false}
+                  onLoad={[Function]}
+                  source={Array []}
+                  style={
+                    Object {
+                      "backgroundColor": "#dddddd",
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "resizeMode": "cover",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <Image
+                  collapsable={undefined}
+                  maintainAspectRatio={false}
+                  onLoad={[Function]}
+                  source={
+                    Array [
+                      Object {
+                        "height": 400,
+                        "uri": "https://picsum.photos/600/400/?random",
+                        "width": 600,
+                      },
+                    ]
+                  }
+                  style={
+                    Object {
+                      "backgroundColor": "#dddddd",
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "resizeMode": "cover",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+              </View>
+              <ExponentLinearGradient
+                colors={
+                  Array [
+                    5783656,
+                    4283973736,
+                  ]
+                }
+                endPoint={
+                  Array [
+                    0,
+                    1,
+                  ]
+                }
+                locations={
+                  Array [
+                    0.3,
+                    1,
+                  ]
+                }
+                startPoint={
+                  Array [
+                    0,
+                    0,
+                  ]
+                }
+                style={
+                  Object {
+                    "bottom": 0,
+                    "left": 0,
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                  }
+                }
+              />
+            </View>
           </View>
           <View
             style={
@@ -696,16 +808,66 @@ exports[`The FeedView component renders empty state 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "width": "100%",
+              }
+            }
+          >
             <View
               style={
                 Object {
-                  "aspectRatio": 1,
-                  "backgroundColor": "#dddddd",
-                  "width": "100%",
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
-            />
+            >
+              <View
+                style={
+                  Object {
+                    "aspectRatio": 1,
+                    "backgroundColor": "#dddddd",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  blurRadius={2}
+                  collapsable={undefined}
+                  maintainAspectRatio={false}
+                  onLoad={[Function]}
+                  source={Array []}
+                  style={
+                    Object {
+                      "backgroundColor": "#dddddd",
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "resizeMode": "cover",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "aspectRatio": 1,
+                      "backgroundColor": "#dddddd",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </View>
+            </View>
           </View>
           <View
             style={
@@ -869,16 +1031,66 @@ exports[`The FeedView component renders empty state 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "width": "100%",
+              }
+            }
+          >
             <View
               style={
                 Object {
-                  "aspectRatio": 1,
-                  "backgroundColor": "#dddddd",
-                  "width": "100%",
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
-            />
+            >
+              <View
+                style={
+                  Object {
+                    "aspectRatio": 1,
+                    "backgroundColor": "#dddddd",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  blurRadius={2}
+                  collapsable={undefined}
+                  maintainAspectRatio={false}
+                  onLoad={[Function]}
+                  source={Array []}
+                  style={
+                    Object {
+                      "backgroundColor": "#dddddd",
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "resizeMode": "cover",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "aspectRatio": 1,
+                      "backgroundColor": "#dddddd",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </View>
+            </View>
           </View>
           <View
             style={
@@ -1042,16 +1254,66 @@ exports[`The FeedView component renders empty state 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "width": "100%",
+              }
+            }
+          >
             <View
               style={
                 Object {
-                  "aspectRatio": 1,
-                  "backgroundColor": "#dddddd",
-                  "width": "100%",
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
-            />
+            >
+              <View
+                style={
+                  Object {
+                    "aspectRatio": 1,
+                    "backgroundColor": "#dddddd",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  blurRadius={2}
+                  collapsable={undefined}
+                  maintainAspectRatio={false}
+                  onLoad={[Function]}
+                  source={Array []}
+                  style={
+                    Object {
+                      "backgroundColor": "#dddddd",
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "resizeMode": "cover",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "aspectRatio": 1,
+                      "backgroundColor": "#dddddd",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </View>
+            </View>
           </View>
           <View
             style={
@@ -1215,16 +1477,66 @@ exports[`The FeedView component renders empty state 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "width": "100%",
+              }
+            }
+          >
             <View
               style={
                 Object {
-                  "aspectRatio": 1,
-                  "backgroundColor": "#dddddd",
-                  "width": "100%",
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
-            />
+            >
+              <View
+                style={
+                  Object {
+                    "aspectRatio": 1,
+                    "backgroundColor": "#dddddd",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  blurRadius={2}
+                  collapsable={undefined}
+                  maintainAspectRatio={false}
+                  onLoad={[Function]}
+                  source={Array []}
+                  style={
+                    Object {
+                      "backgroundColor": "#dddddd",
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "resizeMode": "cover",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "aspectRatio": 1,
+                      "backgroundColor": "#dddddd",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </View>
+            </View>
           </View>
           <View
             style={
@@ -1388,16 +1700,66 @@ exports[`The FeedView component renders empty state 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "width": "100%",
+              }
+            }
+          >
             <View
               style={
                 Object {
-                  "aspectRatio": 1,
-                  "backgroundColor": "#dddddd",
-                  "width": "100%",
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
-            />
+            >
+              <View
+                style={
+                  Object {
+                    "aspectRatio": 1,
+                    "backgroundColor": "#dddddd",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  blurRadius={2}
+                  collapsable={undefined}
+                  maintainAspectRatio={false}
+                  onLoad={[Function]}
+                  source={Array []}
+                  style={
+                    Object {
+                      "backgroundColor": "#dddddd",
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "resizeMode": "cover",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "aspectRatio": 1,
+                      "backgroundColor": "#dddddd",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </View>
+            </View>
           </View>
           <View
             style={
@@ -1561,16 +1923,66 @@ exports[`The FeedView component renders empty state 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "width": "100%",
+              }
+            }
+          >
             <View
               style={
                 Object {
-                  "aspectRatio": 1,
-                  "backgroundColor": "#dddddd",
-                  "width": "100%",
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
-            />
+            >
+              <View
+                style={
+                  Object {
+                    "aspectRatio": 1,
+                    "backgroundColor": "#dddddd",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  blurRadius={2}
+                  collapsable={undefined}
+                  maintainAspectRatio={false}
+                  onLoad={[Function]}
+                  source={Array []}
+                  style={
+                    Object {
+                      "backgroundColor": "#dddddd",
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "resizeMode": "cover",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "aspectRatio": 1,
+                      "backgroundColor": "#dddddd",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </View>
+            </View>
           </View>
           <View
             style={
@@ -1734,16 +2146,66 @@ exports[`The FeedView component renders empty state 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "width": "100%",
+              }
+            }
+          >
             <View
               style={
                 Object {
-                  "aspectRatio": 1,
-                  "backgroundColor": "#dddddd",
-                  "width": "100%",
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
-            />
+            >
+              <View
+                style={
+                  Object {
+                    "aspectRatio": 1,
+                    "backgroundColor": "#dddddd",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  blurRadius={2}
+                  collapsable={undefined}
+                  maintainAspectRatio={false}
+                  onLoad={[Function]}
+                  source={Array []}
+                  style={
+                    Object {
+                      "backgroundColor": "#dddddd",
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "resizeMode": "cover",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "aspectRatio": 1,
+                      "backgroundColor": "#dddddd",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </View>
+            </View>
           </View>
           <View
             style={
@@ -1907,16 +2369,66 @@ exports[`The FeedView component renders empty state 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "width": "100%",
+              }
+            }
+          >
             <View
               style={
                 Object {
-                  "aspectRatio": 1,
-                  "backgroundColor": "#dddddd",
-                  "width": "100%",
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
-            />
+            >
+              <View
+                style={
+                  Object {
+                    "aspectRatio": 1,
+                    "backgroundColor": "#dddddd",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  blurRadius={2}
+                  collapsable={undefined}
+                  maintainAspectRatio={false}
+                  onLoad={[Function]}
+                  source={Array []}
+                  style={
+                    Object {
+                      "backgroundColor": "#dddddd",
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "resizeMode": "cover",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "aspectRatio": 1,
+                      "backgroundColor": "#dddddd",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </View>
+            </View>
           </View>
           <View
             style={
@@ -2080,16 +2592,66 @@ exports[`The FeedView component renders empty state 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "width": "100%",
+              }
+            }
+          >
             <View
               style={
                 Object {
-                  "aspectRatio": 1,
-                  "backgroundColor": "#dddddd",
-                  "width": "100%",
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
-            />
+            >
+              <View
+                style={
+                  Object {
+                    "aspectRatio": 1,
+                    "backgroundColor": "#dddddd",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  blurRadius={2}
+                  collapsable={undefined}
+                  maintainAspectRatio={false}
+                  onLoad={[Function]}
+                  source={Array []}
+                  style={
+                    Object {
+                      "backgroundColor": "#dddddd",
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "resizeMode": "cover",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "aspectRatio": 1,
+                      "backgroundColor": "#dddddd",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </View>
+            </View>
           </View>
           <View
             style={
@@ -2253,16 +2815,66 @@ exports[`The FeedView component renders empty state 1`] = `
             }
           }
         >
-          <View>
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "width": "100%",
+              }
+            }
+          >
             <View
               style={
                 Object {
-                  "aspectRatio": 1,
-                  "backgroundColor": "#dddddd",
-                  "width": "100%",
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                 }
               }
-            />
+            >
+              <View
+                style={
+                  Object {
+                    "aspectRatio": 1,
+                    "backgroundColor": "#dddddd",
+                    "width": "100%",
+                  }
+                }
+              >
+                <Image
+                  blurRadius={2}
+                  collapsable={undefined}
+                  maintainAspectRatio={false}
+                  onLoad={[Function]}
+                  source={Array []}
+                  style={
+                    Object {
+                      "backgroundColor": "#dddddd",
+                      "bottom": 0,
+                      "height": "100%",
+                      "left": 0,
+                      "opacity": 0,
+                      "position": "absolute",
+                      "resizeMode": "cover",
+                      "right": 0,
+                      "top": 0,
+                      "width": "100%",
+                    }
+                  }
+                />
+                <View
+                  style={
+                    Object {
+                      "aspectRatio": 1,
+                      "backgroundColor": "#dddddd",
+                      "width": "100%",
+                    }
+                  }
+                />
+              </View>
+            </View>
           </View>
           <View
             style={

--- a/src/@ui/FeedView/index.js
+++ b/src/@ui/FeedView/index.js
@@ -5,7 +5,7 @@ import { Link } from '@ui/NativeWebRouter';
 import { pure, compose, branch, withProps, defaultProps } from 'recompose';
 import { get } from 'lodash';
 
-import { getLinkPath, getItemBgColor, getItemImages, getItemIsLight } from '@utils/content';
+import { getLinkPath, getItemBgColor, getItemImages, getItemIsLight, getItemThumbnail } from '@utils/content';
 import FeedItemCard from '@ui/FeedItemCard';
 import { enhancer as mediaQuery } from '@ui/MediaQuery';
 import FeedList from './FeedList';
@@ -19,6 +19,7 @@ export const defaultFeedItemRenderer = (CardComponent = FeedItemCard) => (
       title={item.title || item.name || ' '}
       category={item.category}
       images={getItemImages(item)}
+      thumbnail={getItemThumbnail(item)}
       backgroundColor={getItemBgColor(item)}
       isLight={getItemIsLight(item)}
       isLoading={item.isLoading}

--- a/src/@ui/GradientOverlayImage/__snapshots__/GradientOverlayImage.tests.js.snap
+++ b/src/@ui/GradientOverlayImage/__snapshots__/GradientOverlayImage.tests.js.snap
@@ -1,81 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`the GradientOverlayImage component should render 1`] = `
-<View>
-  <Image
-    maintainAspectRatio={false}
-    source={
-      Array [
-        Object {
-          "height": 400,
-          "uri": "https://picsum.photos/600/400/?random",
-          "width": 600,
-        },
-      ]
+<View
+  style={
+    Object {
+      "aspectRatio": 1,
+      "width": "100%",
     }
-    style={
-      Array [
-        Object {},
-        Object {
-          "aspectRatio": 1,
-          "resizeMode": "cover",
-          "width": "100%",
-        },
-      ]
-    }
-  />
-</View>
-`;
-
-exports[`the GradientOverlayImage component should render with an overlayColor 1`] = `
-<View>
-  <Image
-    maintainAspectRatio={false}
-    source={
-      Array [
-        Object {
-          "height": 400,
-          "uri": "https://picsum.photos/600/400/?random",
-          "width": 600,
-        },
-      ]
-    }
-    style={
-      Array [
-        Object {},
-        Object {
-          "aspectRatio": 1,
-          "resizeMode": "cover",
-          "width": "100%",
-        },
-      ]
-    }
-  />
-  <ExponentLinearGradient
-    colors={
-      Array [
-        16416882,
-        4294606962,
-      ]
-    }
-    endPoint={
-      Array [
-        0,
-        1,
-      ]
-    }
-    locations={
-      Array [
-        0.3,
-        1,
-      ]
-    }
-    startPoint={
-      Array [
-        0,
-        0,
-      ]
-    }
+  }
+>
+  <View
     style={
       Object {
         "bottom": 0,
@@ -85,6 +19,112 @@ exports[`the GradientOverlayImage component should render with an overlayColor 1
         "top": 0,
       }
     }
-  />
+  >
+    <Image
+      collapsable={undefined}
+      maintainAspectRatio={false}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "height": 400,
+            "uri": "https://picsum.photos/600/400/?random",
+            "width": 600,
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#dddddd",
+          "height": "100%",
+          "opacity": 0,
+          "resizeMode": "cover",
+          "width": "100%",
+        }
+      }
+    />
+  </View>
+</View>
+`;
+
+exports[`the GradientOverlayImage component should render with an overlayColor 1`] = `
+<View
+  style={
+    Object {
+      "aspectRatio": 1,
+      "width": "100%",
+    }
+  }
+>
+  <View
+    style={
+      Object {
+        "bottom": 0,
+        "left": 0,
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <Image
+      collapsable={undefined}
+      maintainAspectRatio={false}
+      onLoad={[Function]}
+      source={
+        Array [
+          Object {
+            "height": 400,
+            "uri": "https://picsum.photos/600/400/?random",
+            "width": 600,
+          },
+        ]
+      }
+      style={
+        Object {
+          "backgroundColor": "#dddddd",
+          "height": "100%",
+          "opacity": 0,
+          "resizeMode": "cover",
+          "width": "100%",
+        }
+      }
+    />
+    <ExponentLinearGradient
+      colors={
+        Array [
+          16416882,
+          4294606962,
+        ]
+      }
+      endPoint={
+        Array [
+          0,
+          1,
+        ]
+      }
+      locations={
+        Array [
+          0.3,
+          1,
+        ]
+      }
+      startPoint={
+        Array [
+          0,
+          0,
+        ]
+      }
+      style={
+        Object {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        }
+      }
+    />
+  </View>
 </View>
 `;

--- a/src/@ui/GradientOverlayImage/index.js
+++ b/src/@ui/GradientOverlayImage/index.js
@@ -8,20 +8,23 @@ import styled from '@ui/styled';
 import ConnectedImage from '@ui/ConnectedImage';
 import LinearGradient from '@ui/LinearGradient';
 
+const source = PropTypes.oneOfType([
+  PropTypes.arrayOf(
+    PropTypes.shape({
+      uri: PropTypes.string,
+      label: PropTypes.string,
+      width: PropTypes.number,
+      height: PropTypes.number,
+    }),
+  ),
+  PropTypes.string,
+]);
+
 const enhance = compose(
   pure,
   setPropTypes({
-    source: PropTypes.oneOfType([
-      PropTypes.arrayOf(
-        PropTypes.shape({
-          uri: PropTypes.string,
-          label: PropTypes.string,
-          width: PropTypes.number,
-          height: PropTypes.number,
-        }),
-      ),
-      PropTypes.string,
-    ]),
+    source,
+    thumbnail: source,
     overlayColor: PropTypes.string,
     ImageComponent: PropTypes.func,
   }),
@@ -45,10 +48,9 @@ const getGradientValues = (overlayColor) => {
   return values;
 };
 
-const DefaultImageComponent = styled({
+const Container = styled({
   width: '100%',
   aspectRatio: 1,
-  resizeMode: 'cover',
   ...Platform.select({
     web: {
       // web doesn't support aspectRatio, this hacks it:
@@ -56,6 +58,12 @@ const DefaultImageComponent = styled({
       paddingTop: '100%',
     },
   }),
+})(View);
+
+const DefaultImageComponent = styled({
+  width: '100%',
+  height: '100%',
+  resizeMode: 'cover',
 })(ConnectedImage);
 
 const GradientOverlayImage = enhance(
@@ -64,8 +72,8 @@ const GradientOverlayImage = enhance(
   }) => {
     const Component = ComponentProp || DefaultImageComponent;
     return (
-      <View {...otherProps}>
-        <Component source={imageSource} />
+      <Container>
+        <Component source={imageSource} {...otherProps} />
         {overlayColor ? (
           <Overlay
             colors={getGradientValues(overlayColor).colors}
@@ -74,7 +82,7 @@ const GradientOverlayImage = enhance(
             locations={getGradientValues(overlayColor).locations}
           />
         ) : null}
-      </View>
+      </Container>
     );
   },
 );

--- a/src/@ui/GradientOverlayImage/index.js
+++ b/src/@ui/GradientOverlayImage/index.js
@@ -60,6 +60,8 @@ const Container = styled({
   }),
 })(View);
 
+const WebPositioningFix = styled(StyleSheet.absoluteFill)(View);
+
 const DefaultImageComponent = styled({
   width: '100%',
   height: '100%',
@@ -73,15 +75,17 @@ const GradientOverlayImage = enhance(
     const Component = ComponentProp || DefaultImageComponent;
     return (
       <Container>
-        <Component source={imageSource} {...otherProps} />
-        {overlayColor ? (
-          <Overlay
-            colors={getGradientValues(overlayColor).colors}
-            start={getGradientValues(overlayColor).start}
-            end={getGradientValues(overlayColor).end}
-            locations={getGradientValues(overlayColor).locations}
-          />
-        ) : null}
+        <WebPositioningFix>
+          <Component source={imageSource} {...otherProps} />
+          {overlayColor ? (
+            <Overlay
+              colors={getGradientValues(overlayColor).colors}
+              start={getGradientValues(overlayColor).start}
+              end={getGradientValues(overlayColor).end}
+              locations={getGradientValues(overlayColor).locations}
+            />
+          ) : null}
+        </WebPositioningFix>
       </Container>
     );
   },

--- a/src/@ui/ProgressiveImage/ProgressiveImage.tests.js
+++ b/src/@ui/ProgressiveImage/ProgressiveImage.tests.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { ThemeProvider } from '@ui/theme';
+
+import ProgressiveImage from './';
+
+describe('the ProgressiveImage component', () => {
+  it('should render', () => {
+    const tree = renderer.create(
+      <ThemeProvider>
+        <ProgressiveImage
+          source={{
+            uri: 'https://placeholdit.co/i/1500x1500',
+            width: 1500,
+            height: 1500,
+          }}
+          thumbnail={{
+            uri: 'https://placeholdit.co/i/50x50',
+            width: 50,
+            height: 50,
+          }}
+        />
+      </ThemeProvider>,
+    );
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/@ui/ProgressiveImage/__snapshots__/ProgressiveImage.tests.js.snap
+++ b/src/@ui/ProgressiveImage/__snapshots__/ProgressiveImage.tests.js.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the ProgressiveImage component should render 1`] = `
+<View
+  style={
+    Object {
+      "aspectRatio": 1,
+      "backgroundColor": "#dddddd",
+      "width": "100%",
+    }
+  }
+>
+  <Image
+    blurRadius={2}
+    collapsable={undefined}
+    maintainAspectRatio={false}
+    onLoad={[Function]}
+    source={
+      Array [
+        Object {
+          "height": 50,
+          "uri": "https://placeholdit.co/i/50x50",
+          "width": 50,
+        },
+      ]
+    }
+    style={
+      Object {
+        "backgroundColor": "#dddddd",
+        "bottom": 0,
+        "height": "100%",
+        "left": 0,
+        "opacity": 0,
+        "position": "absolute",
+        "resizeMode": "cover",
+        "right": 0,
+        "top": 0,
+        "width": "100%",
+      }
+    }
+  />
+  <Image
+    collapsable={undefined}
+    maintainAspectRatio={false}
+    onLoad={[Function]}
+    source={
+      Array [
+        Object {
+          "height": 1500,
+          "uri": "https://placeholdit.co/i/1500x1500",
+          "width": 1500,
+        },
+      ]
+    }
+    style={
+      Object {
+        "backgroundColor": "#dddddd",
+        "bottom": 0,
+        "height": "100%",
+        "left": 0,
+        "opacity": 0,
+        "position": "absolute",
+        "resizeMode": "cover",
+        "right": 0,
+        "top": 0,
+        "width": "100%",
+      }
+    }
+  />
+</View>
+`;

--- a/src/@ui/ProgressiveImage/index.js
+++ b/src/@ui/ProgressiveImage/index.js
@@ -1,0 +1,99 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { Animated, View, StyleSheet } from 'react-native';
+import styled from '@ui/styled';
+import ConnectedImage from '@ui/ConnectedImage';
+
+const Wrapper = styled(({ theme }) => ({
+  ...StyleSheet.absoluteFillObject,
+  width: '100%',
+  height: '100%',
+  backgroundColor: theme.colors.background.inactive,
+}))(View);
+
+const styles = StyleSheet.create({
+  imageStyles: {
+    ...StyleSheet.absoluteFillObject,
+    width: '100%',
+    height: '100%',
+    resizeMode: 'cover',
+  },
+});
+
+class ProgressiveImage extends PureComponent {
+  static propTypes = {
+    source: ConnectedImage.propTypes.source,
+    thumbnail: ConnectedImage.propTypes.source,
+    thumbnailFadeDuration: PropTypes.number,
+    imageFadeDuration: PropTypes.number,
+    thumbnailBlurRadius: PropTypes.number,
+    onLoadThumbnail: PropTypes.func,
+    onLoadImage: PropTypes.func,
+    containerStyle: PropTypes.any, // eslint-disable-line
+    ...ConnectedImage.propTypes,
+  }
+
+  static defaultProps = {
+    thumbnailFadeDuration: 250,
+    imageFadeDuration: 250,
+    thumbnailBlurRadius: 5,
+    onLoadThumbnail: () => {},
+    onLoadImage: () => {},
+  }
+
+  onLoadThumbnail = (...args) => {
+    Animated.timing(this.thumbnailOpacity, {
+      toValue: 1,
+      duration: this.props.thumbnailFadeDuration,
+    }).start();
+    this.props.onLoadThumbnail(...args);
+  }
+
+  onLoadImage = (...args) => {
+    Animated.timing(this.imageOpacity, {
+      toValue: 1,
+      duration: this.props.imageFadeDuration,
+    }).start();
+    this.props.onLoadImage(...args);
+  }
+
+  thumbnailOpacity = new Animated.Value(0);
+  imageOpacity = new Animated.Value(0);
+
+  render() {
+    const {
+      source,
+      thumbnail,
+      thumbnailFadeDuration,
+      imageFadeDuration,
+      thumbnailBlurRadius,
+      onLoadThumbnail,
+      onLoadImage,
+      style,
+      containerStyle,
+      ...imageProps
+    } = this.props;
+    return (
+      <Wrapper style={containerStyle}>
+        {(thumbnail) ? (
+          <ConnectedImage
+            ImageComponent={Animated.Image}
+            {...imageProps}
+            onLoad={this.onLoadThumbnail}
+            style={[styles.imageStyles, { opacity: this.thumbnailOpacity }, style]}
+            source={thumbnail}
+          />
+        ) : null}
+        <ConnectedImage
+          ImageComponent={Animated.Image}
+          {...imageProps}
+          style={[styles.imageStyles, { opacity: this.imageOpacity }, style]}
+          onLoad={this.onLoadImage}
+          source={source}
+        />
+      </Wrapper>
+    );
+  }
+}
+
+export default ProgressiveImage;

--- a/src/@ui/ProgressiveImage/index.js
+++ b/src/@ui/ProgressiveImage/index.js
@@ -5,9 +5,8 @@ import styled from '@ui/styled';
 import ConnectedImage from '@ui/ConnectedImage';
 
 const Wrapper = styled(({ theme }) => ({
-  ...StyleSheet.absoluteFillObject,
   width: '100%',
-  height: '100%',
+  aspectRatio: 1,
   backgroundColor: theme.colors.background.inactive,
 }))(View);
 
@@ -29,7 +28,7 @@ class ProgressiveImage extends PureComponent {
     thumbnailBlurRadius: PropTypes.number,
     onLoadThumbnail: PropTypes.func,
     onLoadImage: PropTypes.func,
-    containerStyle: PropTypes.any, // eslint-disable-line
+    imageStyle: PropTypes.any, // eslint-disable-line
     ...ConnectedImage.propTypes,
   }
 
@@ -69,25 +68,25 @@ class ProgressiveImage extends PureComponent {
       thumbnailBlurRadius,
       onLoadThumbnail,
       onLoadImage,
+      imageStyle,
       style,
-      containerStyle,
       ...imageProps
     } = this.props;
     return (
-      <Wrapper style={containerStyle}>
+      <Wrapper style={style}>
         {(thumbnail) ? (
           <ConnectedImage
             ImageComponent={Animated.Image}
             {...imageProps}
             onLoad={this.onLoadThumbnail}
-            style={[styles.imageStyles, { opacity: this.thumbnailOpacity }, style]}
+            style={[styles.imageStyles, { opacity: this.thumbnailOpacity }, imageStyle]}
             source={thumbnail}
           />
         ) : null}
         <ConnectedImage
           ImageComponent={Animated.Image}
           {...imageProps}
-          style={[styles.imageStyles, { opacity: this.imageOpacity }, style]}
+          style={[styles.imageStyles, { opacity: this.imageOpacity }, imageStyle]}
           onLoad={this.onLoadImage}
           source={source}
         />

--- a/src/@ui/ProgressiveImage/index.js
+++ b/src/@ui/ProgressiveImage/index.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Animated, View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Platform } from 'react-native';
 import styled from '@ui/styled';
 import ConnectedImage from '@ui/ConnectedImage';
 
@@ -16,6 +16,12 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
     resizeMode: 'cover',
+    ...Platform.select({
+      web: {
+        height: 0,
+        paddingTop: '100%',
+      },
+    }),
   },
 });
 
@@ -23,41 +29,14 @@ class ProgressiveImage extends PureComponent {
   static propTypes = {
     source: ConnectedImage.propTypes.source,
     thumbnail: ConnectedImage.propTypes.source,
-    thumbnailFadeDuration: PropTypes.number,
-    imageFadeDuration: PropTypes.number,
     thumbnailBlurRadius: PropTypes.number,
-    onLoadThumbnail: PropTypes.func,
-    onLoadImage: PropTypes.func,
     imageStyle: PropTypes.any, // eslint-disable-line
     ...ConnectedImage.propTypes,
   }
 
   static defaultProps = {
-    thumbnailFadeDuration: 250,
-    imageFadeDuration: 250,
-    thumbnailBlurRadius: 5,
-    onLoadThumbnail: () => {},
-    onLoadImage: () => {},
+    thumbnailBlurRadius: 2,
   }
-
-  onLoadThumbnail = (...args) => {
-    Animated.timing(this.thumbnailOpacity, {
-      toValue: 1,
-      duration: this.props.thumbnailFadeDuration,
-    }).start();
-    this.props.onLoadThumbnail(...args);
-  }
-
-  onLoadImage = (...args) => {
-    Animated.timing(this.imageOpacity, {
-      toValue: 1,
-      duration: this.props.imageFadeDuration,
-    }).start();
-    this.props.onLoadImage(...args);
-  }
-
-  thumbnailOpacity = new Animated.Value(0);
-  imageOpacity = new Animated.Value(0);
 
   render() {
     const {
@@ -76,18 +55,15 @@ class ProgressiveImage extends PureComponent {
       <Wrapper style={style}>
         {(thumbnail) ? (
           <ConnectedImage
-            ImageComponent={Animated.Image}
             {...imageProps}
-            onLoad={this.onLoadThumbnail}
-            style={[styles.imageStyles, { opacity: this.thumbnailOpacity }, imageStyle]}
+            blurRadius={thumbnailBlurRadius}
+            style={[styles.imageStyles, imageStyle]}
             source={thumbnail}
           />
         ) : null}
         <ConnectedImage
-          ImageComponent={Animated.Image}
           {...imageProps}
-          style={[styles.imageStyles, { opacity: this.imageOpacity }, imageStyle]}
-          onLoad={this.onLoadImage}
+          style={[styles.imageStyles, imageStyle]}
           source={source}
         />
       </Wrapper>

--- a/src/@ui/RelatedContent/__snapshots__/RelatedContent.tests.js.snap
+++ b/src/@ui/RelatedContent/__snapshots__/RelatedContent.tests.js.snap
@@ -125,33 +125,50 @@ exports[`The RelatedContent component renders correctly 1`] = `
               }
             }
           >
-            <Image
-              maintainAspectRatio={false}
-              source={
-                Array [
-                  Object {
-                    "height": 400,
-                    "uri": "https://picsum.photos/600/400/?random",
-                    "width": 600,
-                  },
-                ]
-              }
+            <View
               style={
-                Array [
-                  Object {},
+                Object {
+                  "aspectRatio": 1,
+                  "backgroundColor": "#dddddd",
+                  "bottom": 0,
+                  "height": "100%",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            >
+              <Image
+                collapsable={undefined}
+                maintainAspectRatio={false}
+                onLoad={[Function]}
+                source={
+                  Array [
+                    Object {
+                      "height": 400,
+                      "uri": "https://picsum.photos/600/400/?random",
+                      "width": 600,
+                    },
+                  ]
+                }
+                style={
                   Object {
+                    "backgroundColor": "#dddddd",
                     "bottom": 0,
                     "height": "100%",
                     "left": 0,
+                    "opacity": 0,
                     "position": "absolute",
                     "resizeMode": "cover",
                     "right": 0,
                     "top": 0,
                     "width": "100%",
-                  },
-                ]
-              }
-            />
+                  }
+                }
+              />
+            </View>
           </View>
         </View>
       </View>
@@ -300,33 +317,50 @@ exports[`The RelatedContent component renders correctly 1`] = `
               }
             }
           >
-            <Image
-              maintainAspectRatio={false}
-              source={
-                Array [
-                  Object {
-                    "height": 400,
-                    "uri": "https://picsum.photos/600/400/?random",
-                    "width": 600,
-                  },
-                ]
-              }
+            <View
               style={
-                Array [
-                  Object {},
+                Object {
+                  "aspectRatio": 1,
+                  "backgroundColor": "#dddddd",
+                  "bottom": 0,
+                  "height": "100%",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            >
+              <Image
+                collapsable={undefined}
+                maintainAspectRatio={false}
+                onLoad={[Function]}
+                source={
+                  Array [
+                    Object {
+                      "height": 400,
+                      "uri": "https://picsum.photos/600/400/?random",
+                      "width": 600,
+                    },
+                  ]
+                }
+                style={
                   Object {
+                    "backgroundColor": "#dddddd",
                     "bottom": 0,
                     "height": "100%",
                     "left": 0,
+                    "opacity": 0,
                     "position": "absolute",
                     "resizeMode": "cover",
                     "right": 0,
                     "top": 0,
                     "width": "100%",
-                  },
-                ]
-              }
-            />
+                  }
+                }
+              />
+            </View>
           </View>
         </View>
       </View>
@@ -475,33 +509,50 @@ exports[`The RelatedContent component renders correctly 1`] = `
               }
             }
           >
-            <Image
-              maintainAspectRatio={false}
-              source={
-                Array [
-                  Object {
-                    "height": 400,
-                    "uri": "https://picsum.photos/600/400/?random",
-                    "width": 600,
-                  },
-                ]
-              }
+            <View
               style={
-                Array [
-                  Object {},
+                Object {
+                  "aspectRatio": 1,
+                  "backgroundColor": "#dddddd",
+                  "bottom": 0,
+                  "height": "100%",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            >
+              <Image
+                collapsable={undefined}
+                maintainAspectRatio={false}
+                onLoad={[Function]}
+                source={
+                  Array [
+                    Object {
+                      "height": 400,
+                      "uri": "https://picsum.photos/600/400/?random",
+                      "width": 600,
+                    },
+                  ]
+                }
+                style={
                   Object {
+                    "backgroundColor": "#dddddd",
                     "bottom": 0,
                     "height": "100%",
                     "left": 0,
+                    "opacity": 0,
                     "position": "absolute",
                     "resizeMode": "cover",
                     "right": 0,
                     "top": 0,
                     "width": "100%",
-                  },
-                ]
-              }
-            />
+                  }
+                }
+              />
+            </View>
           </View>
         </View>
       </View>
@@ -635,10 +686,26 @@ exports[`The RelatedContent component renders empty state 1`] = `
                 Object {
                   "aspectRatio": 1,
                   "backgroundColor": "#dddddd",
+                  "bottom": 0,
+                  "height": "100%",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                   "width": "100%",
                 }
               }
-            />
+            >
+              <View
+                style={
+                  Object {
+                    "aspectRatio": 1,
+                    "backgroundColor": "#dddddd",
+                    "width": "100%",
+                  }
+                }
+              />
+            </View>
           </View>
         </View>
       </View>
@@ -740,10 +807,26 @@ exports[`The RelatedContent component renders empty state 1`] = `
                 Object {
                   "aspectRatio": 1,
                   "backgroundColor": "#dddddd",
+                  "bottom": 0,
+                  "height": "100%",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                   "width": "100%",
                 }
               }
-            />
+            >
+              <View
+                style={
+                  Object {
+                    "aspectRatio": 1,
+                    "backgroundColor": "#dddddd",
+                    "width": "100%",
+                  }
+                }
+              />
+            </View>
           </View>
         </View>
       </View>
@@ -845,10 +928,26 @@ exports[`The RelatedContent component renders empty state 1`] = `
                 Object {
                   "aspectRatio": 1,
                   "backgroundColor": "#dddddd",
+                  "bottom": 0,
+                  "height": "100%",
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
                   "width": "100%",
                 }
               }
-            />
+            >
+              <View
+                style={
+                  Object {
+                    "aspectRatio": 1,
+                    "backgroundColor": "#dddddd",
+                    "width": "100%",
+                  }
+                }
+              />
+            </View>
           </View>
         </View>
       </View>

--- a/src/@ui/ThumbnailCard/Thumbnail.js
+++ b/src/@ui/ThumbnailCard/Thumbnail.js
@@ -2,7 +2,7 @@ import { StyleSheet } from 'react-native';
 import { compose } from 'recompose';
 
 import styled from '@ui/styled';
-import ConnectedImage from '@ui/ConnectedImage';
+import ProgressiveImage from '@ui/ProgressiveImage';
 import { getIsLoading } from '@ui/isLoading';
 
 const Image = compose(
@@ -11,10 +11,9 @@ const Image = compose(
     ...StyleSheet.absoluteFillObject,
     width: '100%',
     height: '100%',
-    resizeMode: 'cover',
   }, 'Card.Image'),
-)(ConnectedImage);
+)(ProgressiveImage);
 
-Image.propTypes = ConnectedImage.propTypes;
+Image.propTypes = ProgressiveImage.propTypes;
 
 export default Image;

--- a/src/@ui/ThumbnailCard/__snapshots__/ThumbnailCard.tests.js.snap
+++ b/src/@ui/ThumbnailCard/__snapshots__/ThumbnailCard.tests.js.snap
@@ -183,10 +183,26 @@ exports[`the ThumbnailCard component should render a loading state 1`] = `
             Object {
               "aspectRatio": 1,
               "backgroundColor": "#dddddd",
+              "bottom": 0,
+              "height": "100%",
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
               "width": "100%",
             }
           }
-        />
+        >
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "backgroundColor": "#dddddd",
+                "width": "100%",
+              }
+            }
+          />
+        </View>
       </View>
     </View>
   </View>
@@ -433,10 +449,26 @@ exports[`the ThumbnailCard component should render with a category and images 1`
             Object {
               "aspectRatio": 1,
               "backgroundColor": "#dddddd",
+              "bottom": 0,
+              "height": "100%",
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
               "width": "100%",
             }
           }
-        />
+        >
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "backgroundColor": "#dddddd",
+                "width": "100%",
+              }
+            }
+          />
+        </View>
       </View>
     </View>
   </View>
@@ -520,10 +552,26 @@ exports[`the ThumbnailCard component should render with an images 1`] = `
             Object {
               "aspectRatio": 1,
               "backgroundColor": "#dddddd",
+              "bottom": 0,
+              "height": "100%",
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
               "width": "100%",
             }
           }
-        />
+        >
+          <View
+            style={
+              Object {
+                "aspectRatio": 1,
+                "backgroundColor": "#dddddd",
+                "width": "100%",
+              }
+            }
+          />
+        </View>
       </View>
     </View>
   </View>

--- a/src/@ui/ThumbnailCard/index.js
+++ b/src/@ui/ThumbnailCard/index.js
@@ -57,6 +57,7 @@ const ThumbnailCard = enhance(({
   title,
   description,
   images,
+  thumbnailImage,
   category,
   isLoading,
   children,
@@ -76,7 +77,7 @@ const ThumbnailCard = enhance(({
       </LeftColumn>
       { images ? (
         <RightColumn>
-          <Thumbnail source={images} />
+          <Thumbnail source={images} thumbnail={thumbnailImage} />
         </RightColumn>
       ) : null }
     </HorizontalLayout>

--- a/src/@ui/TileNav/NavItemImage.js
+++ b/src/@ui/TileNav/NavItemImage.js
@@ -1,40 +1,17 @@
-import React, { PureComponent } from 'react';
-import { View, StyleSheet, Dimensions, Animated } from 'react-native';
+import { Platform } from 'react-native';
 import ConnectedImage from '@ui/ConnectedImage';
+import styled from '@ui/styled';
 
-const styles = StyleSheet.create({
-  container: { width: '100%' },
-});
+const NavItemImage = styled({
+  aspectRatio: 1,
+  width: '100%',
+  ...Platform.select({
+    web: {
+      height: 0,
+      paddingTop: '100%',
+    },
+  }),
+})(ConnectedImage);
 
-class NavItemImage extends PureComponent {
-  static propTypes = {
-    source: ConnectedImage.propTypes.source,
-  }
-
-  get imageStyle() {
-    return {
-      width: this.width,
-      height: this.width,
-    };
-  }
-
-  width = new Animated.Value(Dimensions.get('window').width || 0);
-
-  handleLayout = ({ nativeEvent: { layout: { width } } }) => {
-    this.width.setValue(width);
-  }
-
-  render() {
-    return (
-      <View style={styles.container} onLayout={this.handleLayout}>
-        <ConnectedImage
-          {...this.props}
-          ImageComponent={Animated.Image}
-          style={this.imageStyle}
-        />
-      </View>
-    );
-  }
-}
-
+NavItemImage.propTypes = ConnectedImage.propTypes;
 export default NavItemImage;

--- a/src/@utils/content/getItemThumbnail.js
+++ b/src/@utils/content/getItemThumbnail.js
@@ -1,0 +1,9 @@
+import { get } from 'lodash';
+
+const getItemThumbnail = (item) => {
+  let thumbnail = get(item, 'content.thumbnailImage', []);
+  if (!thumbnail.length) thumbnail = get(item, 'parent.content.thumbnailImage', []);
+  return thumbnail;
+};
+
+export default getItemThumbnail;

--- a/src/@utils/content/index.js
+++ b/src/@utils/content/index.js
@@ -1,6 +1,7 @@
 export { default as getLinkPath } from './getLinkPath';
 export { getBlurredImageSource, getAlbumImageSource } from './media';
 export { default as getItemImages } from './getItemImages';
+export { default as getItemThumbnail } from './getItemThumbnail';
 export { default as getItemBgColor } from './getItemBgColor';
 export { default as getItemIsLight } from './getItemIsLight';
 export { default as getSiteLink } from './getSiteLink';

--- a/src/give/Funds/FundCard.js
+++ b/src/give/Funds/FundCard.js
@@ -42,7 +42,7 @@ const FundCard = ({
   <Link to={`/give/campaign/${id}`} key={id}>
     <Card isLoading={isLoading}>
       <ResponsiveSideBySideView>
-        <ImageColumn><CardImage style={{ height: '100%', resizeMode: 'cover' }} source={images} /></ImageColumn>
+        <ImageColumn><CardImage style={{ height: '100%' }} source={images} /></ImageColumn>
         <ContentColumn>
           <CardContent>
             <H4>{name}</H4>

--- a/src/group-finder/GroupCard.js
+++ b/src/group-finder/GroupCard.js
@@ -52,7 +52,6 @@ const ImageColumn = mediaQuery(
 
 const GroupCardImage = styled({
   width: '100%',
-  resizeMode: 'cover',
   aspectRatio: 1.5,
 })(CardImage);
 

--- a/src/group-finder/GroupSingle.js
+++ b/src/group-finder/GroupSingle.js
@@ -5,7 +5,7 @@ import { compose, mapProps, pure } from 'recompose';
 
 import withGroupInfo from '@data/withGroupInfo';
 import Header from '@ui/Header';
-import ConnectedImage from '@ui/ConnectedImage';
+import ProgressiveImage from '@ui/ProgressiveImage';
 import PaddedView from '@ui/PaddedView';
 import BackgroundView from '@ui/BackgroundView';
 import Card from '@ui/Card';
@@ -49,7 +49,7 @@ const StyledImage = styled({
       paddingTop: '50%',
     },
   }),
-})(ConnectedImage);
+})(ProgressiveImage);
 
 const Label = styled(({ theme }) => ({ color: theme.colors.text.tertiary }))(H7);
 const Info = styled(({ theme }) => ({ color: theme.colors.text.secondary }))(H6);

--- a/src/music/Player/FullScreenControls/__snapshots__/FullScreenControls.tests.js.snap
+++ b/src/music/Player/FullScreenControls/__snapshots__/FullScreenControls.tests.js.snap
@@ -11,54 +11,15 @@ exports[`The FullScreenControls component should hide player settings controls i
     }
   }
 >
-  <View>
-    <Image
-      maintainAspectRatio={false}
-      source={
-        Array [
-          Object {
-            "height": 150,
-            "uri": "https://placeholdit.co/i/150x150?bg=eeeeee&fc=577084",
-            "width": 150,
-          },
-        ]
+  <View
+    style={
+      Object {
+        "aspectRatio": 1,
+        "width": "100%",
       }
-      style={
-        Array [
-          Object {},
-          Object {
-            "aspectRatio": 1,
-            "resizeMode": "cover",
-            "width": "100%",
-          },
-        ]
-      }
-    />
-    <ExponentLinearGradient
-      colors={
-        Array [
-          16711680,
-          4294901760,
-        ]
-      }
-      endPoint={
-        Array [
-          0,
-          1,
-        ]
-      }
-      locations={
-        Array [
-          0.3,
-          1,
-        ]
-      }
-      startPoint={
-        Array [
-          0,
-          0,
-        ]
-      }
+    }
+  >
+    <View
       style={
         Object {
           "bottom": 0,
@@ -68,7 +29,66 @@ exports[`The FullScreenControls component should hide player settings controls i
           "top": 0,
         }
       }
-    />
+    >
+      <Image
+        collapsable={undefined}
+        maintainAspectRatio={false}
+        onLoad={[Function]}
+        source={
+          Array [
+            Object {
+              "height": 150,
+              "uri": "https://placeholdit.co/i/150x150?bg=eeeeee&fc=577084",
+              "width": 150,
+            },
+          ]
+        }
+        style={
+          Object {
+            "backgroundColor": "#858585",
+            "height": "100%",
+            "opacity": 0,
+            "resizeMode": "cover",
+            "width": "100%",
+          }
+        }
+      />
+      <ExponentLinearGradient
+        colors={
+          Array [
+            16711680,
+            4294901760,
+          ]
+        }
+        endPoint={
+          Array [
+            0,
+            1,
+          ]
+        }
+        locations={
+          Array [
+            0.3,
+            1,
+          ]
+        }
+        startPoint={
+          Array [
+            0,
+            0,
+          ]
+        }
+        style={
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      />
+    </View>
   </View>
   <RCTSafeAreaView
     style={
@@ -500,54 +520,15 @@ exports[`The FullScreenControls component should render 1`] = `
     }
   }
 >
-  <View>
-    <Image
-      maintainAspectRatio={false}
-      source={
-        Array [
-          Object {
-            "height": 150,
-            "uri": "https://placeholdit.co/i/150x150?bg=eeeeee&fc=577084",
-            "width": 150,
-          },
-        ]
+  <View
+    style={
+      Object {
+        "aspectRatio": 1,
+        "width": "100%",
       }
-      style={
-        Array [
-          Object {},
-          Object {
-            "aspectRatio": 1,
-            "resizeMode": "cover",
-            "width": "100%",
-          },
-        ]
-      }
-    />
-    <ExponentLinearGradient
-      colors={
-        Array [
-          16711680,
-          4294901760,
-        ]
-      }
-      endPoint={
-        Array [
-          0,
-          1,
-        ]
-      }
-      locations={
-        Array [
-          0.3,
-          1,
-        ]
-      }
-      startPoint={
-        Array [
-          0,
-          0,
-        ]
-      }
+    }
+  >
+    <View
       style={
         Object {
           "bottom": 0,
@@ -557,7 +538,66 @@ exports[`The FullScreenControls component should render 1`] = `
           "top": 0,
         }
       }
-    />
+    >
+      <Image
+        collapsable={undefined}
+        maintainAspectRatio={false}
+        onLoad={[Function]}
+        source={
+          Array [
+            Object {
+              "height": 150,
+              "uri": "https://placeholdit.co/i/150x150?bg=eeeeee&fc=577084",
+              "width": 150,
+            },
+          ]
+        }
+        style={
+          Object {
+            "backgroundColor": "#858585",
+            "height": "100%",
+            "opacity": 0,
+            "resizeMode": "cover",
+            "width": "100%",
+          }
+        }
+      />
+      <ExponentLinearGradient
+        colors={
+          Array [
+            16711680,
+            4294901760,
+          ]
+        }
+        endPoint={
+          Array [
+            0,
+            1,
+          ]
+        }
+        locations={
+          Array [
+            0.3,
+            1,
+          ]
+        }
+        startPoint={
+          Array [
+            0,
+            0,
+          ]
+        }
+        style={
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+          }
+        }
+      />
+    </View>
   </View>
   <RCTSafeAreaView
     style={

--- a/src/music/Player/MiniControls/__snapshots__/MiniControls.tests.js.snap
+++ b/src/music/Player/MiniControls/__snapshots__/MiniControls.tests.js.snap
@@ -94,7 +94,9 @@ exports[`The MiniControls component should render 1`] = `
         </View>
       </View>
       <Image
+        collapsable={undefined}
         maintainAspectRatio={false}
+        onLoad={[Function]}
         source={
           Array [
             Object {
@@ -105,12 +107,11 @@ exports[`The MiniControls component should render 1`] = `
           ]
         }
         style={
-          Array [
-            Object {},
-            Object {
-              "aspectRatio": 1,
-            },
-          ]
+          Object {
+            "aspectRatio": 1,
+            "backgroundColor": "#858585",
+            "opacity": 0,
+          }
         }
       />
     </View>


### PR DESCRIPTION
This adds progressive image loading to the app.

Here's an example simulated on a very slow connection:

![screen recording 2018-04-05 at 08 52 am](https://user-images.githubusercontent.com/103927/38370031-b78f07b8-38ae-11e8-9c67-505cb1af0b6e.gif)


## Creator

- [x] Build relevant tests if any apply
- [x] Ensure there are no new warnings
- [x] Upload an animated GIF showcasing the solution (if it applies)
- [x] Set a relevant reviewer

## Reviewer

- [x] Run `test` and make sure all tests pass
- [x] Review function and form on iOS
- [x] Review function and form on Android
- [x] Review function and form on Web
- [x] Review new test logic

