### PR TITLE
Performance: content placeholders

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@expo/react-native-action-sheet": "github:xcarpentier/react-native-action-sheet",
-    "apollo-cache-inmemory": "^1.1.0",
+    "apollo-cache-inmemory": "^1.1.12",
     "apollo-client": "^2.0.2",
     "apollo-link-context": "^1.0.1",
     "apollo-link-error": "^1.0.7",

--- a/src/@data/Client/cache.js
+++ b/src/@data/Client/cache.js
@@ -1,6 +1,7 @@
 import { InMemoryCache, IntrospectionFragmentMatcher, defaultDataIdFromObject } from 'apollo-cache-inmemory';
+import { toIdValue } from 'apollo-utilities';
 
-export default new InMemoryCache({
+const cache = new InMemoryCache({
   dataIdFromObject(obj) {
     // eslint-disable-next-line no-underscore-dangle
     if (obj.entryId) return `${obj.__typename}:${obj.entryId}`;
@@ -11,4 +12,11 @@ export default new InMemoryCache({
     // More Info: ./README.md
     introspectionQueryResultData: JSON.parse('{"__schema":{"types":[{"kind":"INTERFACE","name":"Node","possibleTypes":[{"name":"User"},{"name":"Content"},{"name":"Campus"},{"name":"Location"},{"name":"File"},{"name":"Navigation"},{"name":"Person"},{"name":"PhoneNumber"},{"name":"Group"},{"name":"DefinedValue"},{"name":"GroupSchedule"},{"name":"GroupMember"},{"name":"GroupLocation"},{"name":"Attribute"},{"name":"AttributeValue"},{"name":"SavedPayment"},{"name":"PaymentDetail"},{"name":"Transaction"},{"name":"TransactionDetail"},{"name":"FinancialAccount"},{"name":"ScheduledTransaction"},{"name":"BinaryFile"}]},{"kind":"INTERFACE","name":"MutationResponse","possibleTypes":[{"name":"PhoneNumberMutationResponse"},{"name":"DeviceRegistrationMutationResponse"},{"name":"AttributeValueMutationResponse"},{"name":"OrderMutationResponse"},{"name":"CompleteOrderMutationResponse"},{"name":"ValidateMutationResponse"},{"name":"SavePaymentMutationResponse"},{"name":"ScheduledTransactionMutationResponse"},{"name":"StatementMutationResponse"},{"name":"GroupsMutationResponse"},{"name":"LikesMutationResponse"}]}]}}'),
   }),
+  cacheRedirects: {
+    Query: {
+      node: (_, args) => toIdValue(cache.config.dataIdFromObject({ __typename: 'Content', id: args.id })),
+    },
+  },
 });
+
+export default cache;

--- a/src/@data/Client/cache.js
+++ b/src/@data/Client/cache.js
@@ -1,5 +1,4 @@
 import { InMemoryCache, IntrospectionFragmentMatcher, defaultDataIdFromObject } from 'apollo-cache-inmemory';
-import { toIdValue } from 'apollo-utilities';
 
 const cache = new InMemoryCache({
   dataIdFromObject(obj) {
@@ -14,7 +13,7 @@ const cache = new InMemoryCache({
   }),
   cacheRedirects: {
     Query: {
-      node: (_, args) => toIdValue(cache.config.dataIdFromObject({ __typename: 'Content', id: args.id })),
+      node: (_, { id }, { getCacheKey }) => getCacheKey({ __typename: 'Content', id }),
     },
   },
 });

--- a/src/@data/likes/fragments.js
+++ b/src/@data/likes/fragments.js
@@ -13,11 +13,16 @@ export const contentCard = gql`
         urlTitle
       }
       content {
-        images(sizes: ["medium"]) {
-          url
-          label
+        images(sizes: ["large"]) {
+          fileName
+          fileType
           fileLabel
-          id
+          url
+        }
+        isLight
+        colors {
+          value
+          description
         }
       }
     }
@@ -26,11 +31,16 @@ export const contentCard = gql`
     }
     content {
       isLiked
-      images(sizes: ["medium"]) {
-        url
-        label
+      isLight
+      images(sizes: ["large"]) {
+        fileName
+        fileType
         fileLabel
-        id
+        url
+      }
+      colors {
+        value
+        description
       }
     }
   }

--- a/src/@data/withArticle/index.js
+++ b/src/@data/withArticle/index.js
@@ -2,8 +2,9 @@ import { graphql } from 'react-apollo';
 import articleQuery from './articleQuery';
 
 export default graphql(articleQuery, {
-  props: ({ data: { content } }) => ({
+  props: ({ data: { content, loading }, ownProps }) => ({
     content,
+    isLoading: ownProps.isLoading || loading,
   }),
   options: (ownProps = {}) => ({
     variables: {
@@ -11,4 +12,3 @@ export default graphql(articleQuery, {
     },
   }),
 });
-

--- a/src/@data/withArticles/articlesQuery.js
+++ b/src/@data/withArticles/articlesQuery.js
@@ -26,6 +26,11 @@ export default gql`
           fileLabel
           url
         }
+        isLight
+        colors {
+          value
+          description
+        }
       }
     }
   }

--- a/src/@data/withCachedContent/index.js
+++ b/src/@data/withCachedContent/index.js
@@ -1,0 +1,70 @@
+import gql from 'graphql-tag';
+import { graphql } from 'react-apollo';
+import { merge } from 'lodash';
+
+const cachedContentQuery = gql`
+  query getCachedContent($id: ID!) {
+    content: node(id: $id) {
+      id
+      ... on Content {
+        title
+        status
+        channelName
+        content {
+          isLiked
+          isLight
+          images(sizes: ["large"]) {
+            fileName
+            fileType
+            fileLabel
+            url
+          }
+          colors {
+            value
+            description
+          }
+        }
+      }
+    }
+  }
+`;
+
+const cachedContentParentQuery = gql`
+  query getCachedParentContent($id: ID!) {
+    content: node(id: $id) {
+      id
+      ... on Content {
+        parent {
+          content {
+            images(sizes: ["large"]) {
+              fileName
+              fileType
+              fileLabel
+              url
+            }
+            colors {
+              value
+              description
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const withQuery = query => graphql(query, {
+  props: ({ data: { content, loading }, ownProps }) => ({
+    content: merge({}, (content || {}), (ownProps.content || {})),
+    isLoading: ownProps.isLoading || loading,
+  }),
+  options: (ownProps = {}) => ({
+    variables: {
+      id: ownProps.id,
+    },
+    fetchPolicy: 'cache-only',
+  }),
+});
+
+export default withQuery(cachedContentQuery);
+export const withCachedParentContent = withQuery(cachedContentParentQuery);

--- a/src/@data/withCachedContent/index.js
+++ b/src/@data/withCachedContent/index.js
@@ -8,7 +8,6 @@ const cachedContentQuery = gql`
       id
       ... on Content {
         title
-        status
         channelName
         content {
           isLiked
@@ -36,6 +35,7 @@ const cachedContentParentQuery = gql`
       ... on Content {
         parent {
           content {
+            isLight
             images(sizes: ["large"]) {
               fileName
               fileType

--- a/src/@data/withNewsStories/newsStoriesQuery.js
+++ b/src/@data/withNewsStories/newsStoriesQuery.js
@@ -26,6 +26,11 @@ export default gql`
         video {
           embedUrl
         }
+        isLight
+        colors {
+          value
+          description
+        }
       }
     }
   }

--- a/src/@data/withNewsStory/index.js
+++ b/src/@data/withNewsStory/index.js
@@ -2,8 +2,9 @@ import { graphql } from 'react-apollo';
 import newsStoryQuery from './newsStoryQuery';
 
 export default graphql(newsStoryQuery, {
-  props: ({ data: { content } }) => ({
+  props: ({ data: { content, loading }, ownProps }) => ({
     content,
+    isLoading: ownProps.isLoading || loading,
   }),
   options: (ownProps = {}) => ({
     variables: {

--- a/src/@data/withPromotions/promotionsQuery.js
+++ b/src/@data/withPromotions/promotionsQuery.js
@@ -18,6 +18,11 @@ export default gql`
           url
         }
         isLiked
+        colors {
+          value
+          description
+        }
+        isLight
       }
     }
   }

--- a/src/@data/withRelatedContent/relatedContentQuery.js
+++ b/src/@data/withRelatedContent/relatedContentQuery.js
@@ -17,6 +17,11 @@ export default gql`
             fileLabel
             id
           }
+          colors {
+            value
+            description
+          }
+          isLight
         }
         meta {
           urlTitle
@@ -32,6 +37,11 @@ export default gql`
           fileLabel
           id
         }
+        colors {
+          value
+          description
+        }
+        isLight
       }
     }
   }

--- a/src/@data/withSeriesContent/seriesContentQuery.js
+++ b/src/@data/withSeriesContent/seriesContentQuery.js
@@ -47,6 +47,11 @@ export default gql`
           }
           content {
             speaker
+            colors {
+              value
+              description
+            }
+            isLight
           }
         }
       }

--- a/src/@data/withSermon/sermonQuery.js
+++ b/src/@data/withSermon/sermonQuery.js
@@ -37,6 +37,11 @@ export default gql`
             }
             content {
               speaker
+              colors {
+                value
+                description
+              }
+              isLight
             }
           }
         }

--- a/src/@data/withStories/storiesQuery.js
+++ b/src/@data/withStories/storiesQuery.js
@@ -26,6 +26,11 @@ export default gql`
         video {
           embedUrl
         }
+        colors {
+          value
+          description
+        }
+        isLight
       }
     }
   }

--- a/src/@data/withStory/index.js
+++ b/src/@data/withStory/index.js
@@ -2,8 +2,9 @@ import { graphql } from 'react-apollo';
 import storyQuery from './storyQuery';
 
 export default graphql(storyQuery, {
-  props: ({ data: { content } }) => ({
+  props: ({ data: { content, loading }, ownProps }) => ({
     content,
+    isLoading: ownProps.isLoading || loading,
   }),
   options: (ownProps = {}) => ({
     variables: {

--- a/src/@ui/ContentView/index.js
+++ b/src/@ui/ContentView/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { compose, pure, setPropTypes } from 'recompose';
 import styled from '@ui/styled';
+import Placeholder from '@ui/Placeholder';
 
 import { VideoHeader, ImageHeader, AudioBanner } from './Media';
 
@@ -93,11 +94,15 @@ const ContentView = enhance(
     title,
     audio,
     children,
+    isLoading,
   }) => (
     <View>
       {renderHeader(video, images, imageOverlayColor)}
       {renderAudioBar(contentId, title, audio, seriesImages, seriesColors)}
-      <ContentWrapper>{children}</ContentWrapper>
+      <ContentWrapper>
+        {children}
+        {isLoading ? <Placeholder.Paragraph /> : null}
+      </ContentWrapper>
     </View>
   ),
 );

--- a/src/articles/Single.js
+++ b/src/articles/Single.js
@@ -37,7 +37,7 @@ const ArticleSingle = enhance(({
   <BackgroundView>
     <Header titleText="Article" backButton />
     <ScrollView>
-      <ContentView {...otherContentProps}>
+      <ContentView isLoading={isLoading} {...otherContentProps}>
         <Title>{title}</Title>
         <ByLine authors={authors} />
         <HTMLView>{body}</HTMLView>

--- a/src/articles/Single.js
+++ b/src/articles/Single.js
@@ -3,6 +3,7 @@ import { ScrollView } from 'react-native';
 import { compose, mapProps, pure } from 'recompose';
 
 import withArticle from '@data/withArticle';
+import withCachedContent from '@data/withCachedContent';
 import BackgroundView from '@ui/BackgroundView';
 import Header from '@ui/Header';
 import ContentView, { Title, ByLine, HTMLView } from '@ui/ContentView';
@@ -14,6 +15,7 @@ const enhance = compose(
   pure,
   mapProps(({ match: { params: { id } } }) => ({ id })),
   withArticle,
+  withCachedContent,
 );
 
 const ShareLink = withArticle(Share);

--- a/src/news/Single.js
+++ b/src/news/Single.js
@@ -9,11 +9,13 @@ import ContentView, { Title, ByLine, HTMLView } from '@ui/ContentView';
 import MediaQuery from '@ui/MediaQuery';
 import SecondaryNav, { Like, Share } from '@ui/SecondaryNav';
 import withNewsStory from '@data/withNewsStory';
+import withCachedContent from '@data/withCachedContent';
 
 const enhance = compose(
   pure,
   mapProps(({ match: { params: { id } } }) => ({ id })),
   withNewsStory,
+  withCachedContent,
 );
 
 const ShareLink = withNewsStory(Share);

--- a/src/news/Single.js
+++ b/src/news/Single.js
@@ -31,11 +31,12 @@ const NewsSingle = enhance(({
       ...otherContentProps
     } = {},
   } = { },
+  isLoading,
 }) => (
   <BackgroundView>
     <Header titleText="News" backButton />
     <ScrollView>
-      <ContentView {...otherContentProps}>
+      <ContentView isLoading={isLoading} {...otherContentProps}>
         <Title>{startCase(toLower(title))}</Title>
         <ByLine authors={authors} />
         <HTMLView>{body}</HTMLView>

--- a/src/series/Sermon.js
+++ b/src/series/Sermon.js
@@ -10,11 +10,14 @@ import SecondaryNav, { Like, Share } from '@ui/SecondaryNav';
 import withSermon from '@data/withSermon';
 import { withThemeMixin } from '@ui/theme';
 import HorizontalTileFeed from '@ui/HorizontalTileFeed';
+import withCachedContent, { withCachedParentContent } from '@data/withCachedContent';
 
 const enhance = compose(
   pure,
   mapProps(({ match: { params: { id } } }) => ({ id })),
   withSermon,
+  withCachedContent,
+  withCachedParentContent,
   withThemeMixin(({ content: { parent: { content = {} } = {} } = {} } = {}) => {
     const theme = {};
     if (content.colors && content.colors.length) {

--- a/src/series/Sermon.js
+++ b/src/series/Sermon.js
@@ -58,6 +58,7 @@ const Sermon = enhance(
       />
       <ScrollView>
         <ContentView
+          isLoading={isLoading}
           title={title}
           seriesImages={seriesImages}
           seriesColors={seriesColors}

--- a/src/series/Single.js
+++ b/src/series/Single.js
@@ -4,7 +4,6 @@ import { ScrollView } from 'react-native';
 import { get } from 'lodash';
 
 import withSeriesContent from '@data/withSeriesContent';
-import { withIsLoading } from '@ui/isLoading';
 import BackgroundView from '@ui/BackgroundView';
 import Header from '@ui/Header';
 import ContentView, { HTMLView } from '@ui/ContentView';
@@ -41,7 +40,6 @@ const enhance = compose(
     return theme;
   }),
   withTheme(),
-  withIsLoading,
 );
 
 const ShareLink = withSeriesContent(Share);

--- a/src/series/Single.js
+++ b/src/series/Single.js
@@ -17,11 +17,13 @@ import styled from '@ui/styled';
 import HorizontalTileFeed from '@ui/HorizontalTileFeed';
 import RelatedContent from '@ui/RelatedContent';
 import { withRouter } from '@ui/NativeWebRouter';
+import withCachedContent from '@data/withCachedContent';
 
 const enhance = compose(
   pure,
   mapProps(({ match: { params: { id } } }) => ({ id })),
   withSeriesContent,
+  withCachedContent,
   withRouter,
   withThemeMixin(({ content: { content = {} } = {} } = {}) => {
     const theme = {
@@ -73,7 +75,11 @@ const SeriesSingle = enhance(({
       barStyle={isLight ? 'dark-content' : 'light-content'}
     />
     <ScrollView>
-      <ContentView imageOverlayColor={(!isLoading && colors && colors.length) ? `#${get(colors, '[0].value')}` : null} {...otherContentProps}>
+      <ContentView
+        isLoading={isLoading}
+        imageOverlayColor={(colors && colors.length) ? `#${get(colors, '[0].value')}` : null}
+        {...otherContentProps}
+      >
         {(video && video.embedUrl) ? (
           <StyledButton onPress={() => history.push(`/series/${id}/trailer`)} type={'ghost'} bordered>
             <Icon name="play" size={theme.helpers.rem(0.875)} fill={theme.colors.text.primary} />

--- a/src/stories/Single.js
+++ b/src/stories/Single.js
@@ -38,13 +38,12 @@ const StorySingle = enhance(({
   <BackgroundView>
     <Header titleText="Story" backButton />
     <ScrollView>
-      <ContentView {...otherContentProps}>
+      <ContentView isLoading={isLoading} {...otherContentProps}>
         <Title>{startCase(toLower(title))}</Title>
         <ByLine authors={authors} />
         <HTMLView>{body}</HTMLView>
       </ContentView>
-      { // Don't render till data is ready. Consider adding placeholder views for the content above.
-        !isLoading && <RelatedContent tags={tags} excludedIds={[id]} />}
+      <RelatedContent tags={tags} excludedIds={[id]} />
     </ScrollView>
     <MediaQuery maxWidth="md">
       <SecondaryNav>

--- a/src/stories/Single.js
+++ b/src/stories/Single.js
@@ -10,11 +10,13 @@ import ContentView, { ByLine, Title, HTMLView } from '@ui/ContentView';
 import MediaQuery from '@ui/MediaQuery';
 import SecondaryNav, { Like, Share } from '@ui/SecondaryNav';
 import RelatedContent from '@ui/RelatedContent';
+import withCachedContent from '@data/withCachedContent';
 
 const enhance = compose(
   pure,
   mapProps(({ match: { params: { id } } }) => ({ id })),
   withStory,
+  withCachedContent,
 );
 
 const ShareLink = withStory(Share);

--- a/src/studies/Entry/DevotionalTab.js
+++ b/src/studies/Entry/DevotionalTab.js
@@ -25,7 +25,7 @@ const DevotionalTab = enhance(({
   isLoading,
 }) => (
   <ScrollView>
-    <ContentView {...otherContentProps} >
+    <ContentView isLoading={isLoading} {...otherContentProps} >
       <Title>{titleCase(title)}</Title>
       <HTMLView>{body}</HTMLView>
     </ContentView>

--- a/src/studies/Entry/EntryList.js
+++ b/src/studies/Entry/EntryList.js
@@ -38,7 +38,7 @@ const EntryList = enhance(({
   isLoading,
 }) => (
   <Wrapper>
-    <Title>{title}</Title>
+    <Title isLoading={false}>{title}</Title>
     <HorizontalTileFeed
       content={entries}
       isLoading={isLoading}

--- a/src/studies/Entry/index.js
+++ b/src/studies/Entry/index.js
@@ -7,6 +7,7 @@ import Header from '@ui/Header';
 import SecondaryNav, { Like, Share } from '@ui/SecondaryNav';
 import TabView, { SceneMap } from '@ui/TabView';
 import { withThemeMixin } from '@ui/theme';
+import withCachedContent, { withCachedParentContent } from '@data/withCachedContent';
 
 import ScriptureTab from './ScriptureTab';
 import DevotionalTab from './DevotionalTab';
@@ -15,6 +16,8 @@ const enhance = compose(
   pure,
   mapProps(({ match: { params: { id } } }) => ({ id })),
   withStudyEntry,
+  withCachedContent,
+  withCachedParentContent,
   withThemeMixin(({ content: { parent: { content = {} } = {} } = {} } = {}) => {
     const theme = { };
     if (content.colors && content.colors.length) {

--- a/src/studies/Single.js
+++ b/src/studies/Single.js
@@ -11,11 +11,13 @@ import SecondaryNav, { Like, Share } from '@ui/SecondaryNav';
 import { withThemeMixin } from '@ui/theme';
 import HorizontalTileFeed from '@ui/HorizontalTileFeed';
 import RelatedContent from '@ui/RelatedContent';
+import withCachedContent from '@data/withCachedContent';
 
 const enhance = compose(
   pure,
   mapProps(({ match: { params: { id } } }) => ({ id })),
   withStudy,
+  withCachedContent,
   withThemeMixin(({ content: { content = {} } = {} } = {}) => {
     const theme = {
       type: content.isLight ? 'light' : 'dark',

--- a/src/studies/Single.js
+++ b/src/studies/Single.js
@@ -60,7 +60,11 @@ const Study = enhance(({
       barStyle={isLight ? 'dark-content' : 'light-content'}
     />
     <ScrollView>
-      <ContentView imageOverlayColor={(!isLoading && colors && colors.length) ? `#${colors[0].value}` : ''} {...otherContentProps}>
+      <ContentView
+        isLoading={isLoading}
+        imageOverlayColor={(!isLoading && colors && colors.length) ? `#${colors[0].value}` : ''}
+        {...otherContentProps}
+      >
         <Title>{startCase(toLower(title))}</Title>
         <HTMLView>{description}</HTMLView>
       </ContentView>

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,19 +703,25 @@ anymatch@^1.3.0:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
 
-apollo-cache-inmemory@^1.1.0:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.1.5.tgz#74111367fd59caee120197ef663dcb2516971300"
+apollo-cache-inmemory@^1.1.12:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.1.12.tgz#ab489bf046b3e026556ab28bdebb6e010cac9531"
   dependencies:
-    apollo-cache "^1.1.0"
-    apollo-utilities "^1.0.4"
-    graphql-anywhere "^4.1.1"
+    apollo-cache "^1.1.7"
+    apollo-utilities "^1.0.11"
+    graphql-anywhere "^4.1.8"
 
 apollo-cache@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.0.tgz#281b6a0fb6ca2c5bce69825642f685de92d05f3c"
   dependencies:
     apollo-utilities "^1.0.4"
+
+apollo-cache@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.7.tgz#5817018a2fbfc05a21ba319bd17a3e7538110cc5"
+  dependencies:
+    apollo-utilities "^1.0.11"
 
 apollo-client@^2.0.2:
   version "2.2.0"
@@ -787,6 +793,10 @@ apollo-link@^1.2.1:
 apollo-utilities@^1.0.0, apollo-utilities@^1.0.1, apollo-utilities@^1.0.3, apollo-utilities@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.4.tgz#560009ea5541b9fdc4ee07ebb1714ee319a76c15"
+
+apollo-utilities@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.11.tgz#cd36bfa6e5c04eea2caf0c204a0f38a0ad550802"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -5549,11 +5559,11 @@ graphql-anywhere@^4.1.0-alpha.0:
   dependencies:
     apollo-utilities "^1.0.3"
 
-graphql-anywhere@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.1.tgz#67924b67b053d1a23bc30d0e4c8db943c1d791a8"
+graphql-anywhere@^4.1.8:
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.8.tgz#23882e6a16ec824febbe5bca40937cdd76c5acdc"
   dependencies:
-    apollo-utilities "^1.0.4"
+    apollo-utilities "^1.0.11"
 
 graphql-subscriptions@^0.5.6:
   version "0.5.6"


### PR DESCRIPTION
This PR does 2 things:

1. Add "cache redirects" for content pieces
2. Improves placeholders in content views

Cache redirects allow us to immediately render content when we're navigating to content that we already have in the cache, but is loaded with a different query. For example, when we navigate from a feed view to an individual item. The individual item is supported by a different query, but we already have some data for that item from the feed view. The net result of this is no more awkward placeholders when navigating between content:

![screen recording 2018-04-05 at 09 01 am](https://user-images.githubusercontent.com/103927/38370545-fa49e14e-38af-11e8-8012-5ff2a7e819d7.gif)

![screen recording 2018-04-05 at 09 02 am](https://user-images.githubusercontent.com/103927/38370626-2a53d6c4-38b0-11e8-9330-5d1a22aa5586.gif)


## Creator

- [x] Build relevant tests if any apply
- [x] Ensure there are no new warnings
- [x] Upload an animated GIF showcasing the solution (if it applies)
- [x] Set a relevant reviewer

## Reviewer

- [x] Run `test` and make sure all tests pass
- [x] Review function and form on iOS
- [x] Review function and form on Android
- [x] Review function and form on Web
- [ ] Review new test logic

