### PR TITLE
Force the display of 1:1 images if available

### DIFF
--- a/src/@ui/ContentView/Media/ImageHeader.js
+++ b/src/@ui/ContentView/Media/ImageHeader.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 import GradientOverlayImage from '@ui/GradientOverlayImage';
 import ProgressiveImage from '@ui/ProgressiveImage';
+import { getItemImages } from '@utils/content';
 
 const enhance = compose(
   pure,
@@ -17,7 +18,8 @@ const enhance = compose(
 const ImageHeader = enhance(({ images, thumbnail, imageOverlayColor }) => (
   <GradientOverlayImage
     ImageComponent={ProgressiveImage}
-    source={images}
+    // todo: calling getItemImages like this is kinda dirty
+    source={getItemImages({ content: { images } })}
     thumbnail={thumbnail}
     overlayColor={imageOverlayColor}
   />

--- a/src/@utils/content/getItemImages.js
+++ b/src/@utils/content/getItemImages.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, filter } from 'lodash';
 
 const getItemImages = (item) => {
   let images = item.photo || get(item, 'content.images', []);
@@ -14,6 +14,12 @@ const getItemImages = (item) => {
     if (b && b.fileLabel === '1:1') return 1;
     return 0;
   });
+  // TODO: this is some stop-gap logic to make sure we prioritize showing square images.
+  // Even though we sort 1:1 images to the front above, sometimes React-Native likes to show
+  // other formats based on screen resolution.
+  if (images.find(({ fileLabel }) => fileLabel === '1:1')) {
+    images = filter(images, ({ fileLabel }) => fileLabel === '1:1');
+  }
   return images;
 };
 


### PR DESCRIPTION
Fixes #432 

## Creator

- [x] Build relevant tests if any apply
- [x] Ensure there are no new warnings
- [x] Upload an animated GIF showcasing the solution (if it applies)
- [x] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

