### PR TITLE
Only track user if user is logged in

### DIFF
--- a/src/SentryContext.js
+++ b/src/SentryContext.js
@@ -17,9 +17,7 @@ const SentryContext = withUser(({
 }) => {
   Sentry.setUserContext(id ? { id, email } : null);
 
-  if (!id) {
-    Analytics.identify(null);
-  } else {
+  if (id) {
     Analytics.identify(id, {
       age,
       campusId: get(campus, 'id'),


### PR DESCRIPTION
I believe amplitude is logging a unique user any time we calling `Analytics.identify(null)`, which will skew something like a "Daily new user", "Daily active user", etc.

Fixes [issue-number]

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

