### PR TITLE
Add restricted paths and use singleInstance for universal linking on android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -51,7 +51,7 @@
     <activity
         android:name=".LauncherActivity"
         android:exported="true"
-        android:launchMode="singleTask"
+        android:launchMode="singleInstance"
         android:screenOrientation="portrait"
         android:theme="@android:style/Theme.Translucent.NoTitleBar">
 
@@ -68,20 +68,22 @@
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
 
-        <data
-            android:scheme="http"
-            android:host="newspring.cc" />
+        <data android:scheme="http" android:host="newspring.cc" android:pathPrefix="/series" />
+        <data android:scheme="https" />
+        <data android:scheme="https" android:host="newspring.cc" android:pathPrefix="/series" />
+        <data android:scheme="https" android:host="newspring.cc" android:pathPrefix="/devotion" />
+        <data android:scheme="https" android:host="newspring.cc" android:pathPrefix="/sermon" />
+        <data android:scheme="https" android:host="newspring.cc" android:pathPrefix="/studies" />
+        <data android:scheme="https" android:host="newspring.cc" android:pathPrefix="/stories" />
+        <data android:scheme="https" android:host="newspring.cc" android:pathPrefix="/news" />
+        <data android:scheme="https" android:host="newspring.cc" android:pathPrefix="/music" />
+        <data android:scheme="https" android:host="newspring.cc" android:pathPrefix="/live" />
+        <data android:scheme="https" android:host="newspring.cc" android:pathPrefix="/settings" />
+        <data android:scheme="https" android:host="newspring.cc" android:pathPrefix="/articles" />
+        <data android:scheme="https" android:host="newspring.cc" android:pathPrefix="/groups" />
+        <data android:scheme="https" android:host="newspring.cc" android:pathPrefix="/give" />
       </intent-filter>
-      <intent-filter android:autoVerify="true">
-        <action android:name="android.intent.action.VIEW" />
 
-        <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE" />
-
-        <data
-            android:scheme="https"
-            android:host="newspring.cc" />
-      </intent-filter>
       <intent-filter android:autoVerify="true">
         <action android:name="android.intent.action.VIEW" />
 
@@ -112,7 +114,7 @@
 
     <activity
         android:name=".MainActivity"
-        android:launchMode="singleTask"
+        android:launchMode="singleInstance"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
         android:theme="@style/Theme.Exponent.Splash"
         android:windowSoftInputMode="adjustResize">


### PR DESCRIPTION
Previously Android app was responding to _any_ url that starts with `newspring.cc/`. This adds in a bunch of restrictions so it only responds to certain paths, so it fixes the issue @FrankGrand discovered where location cards weren't working.

Also, it switches the activity type to `singleInstance`, which _should_ also keep only one instance of the app open ever.

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

