### PR TITLE
Fix dup bad cc bug

### DIFF
--- a/src/@data/withGive/resolvers/mutations.js
+++ b/src/@data/withGive/resolvers/mutations.js
@@ -26,16 +26,11 @@ export function addContribution(result, variables, { cache }) {
 }
 
 export function resetContributions(result, variables, { cache }) {
-  const { contributions: state } = cache.readQuery({
-    query: contributionsQuery,
-  });
-
   cache.writeQuery({
     query: contributionsQuery,
     data: {
       contributions: {
-        ...state,
-        contributions: [],
+        ...INITIAL_STATE,
       },
     },
   });

--- a/src/@data/withGive/resolvers/mutations.js
+++ b/src/@data/withGive/resolvers/mutations.js
@@ -357,6 +357,11 @@ export async function setSavedPaymentMethod(result, variables, { cache }) {
       data: {
         contributions: {
           ...state,
+          paymentMethod: 'savedPaymentMethod',
+          creditCard: { ...INITIAL_STATE.creditCard },
+          bankAccount: { ...INITIAL_STATE.bankAccount },
+          willSavePaymentMethod: false,
+          savedAccountName: '',
           savedPaymentMethodId: variables.id,
         },
       },

--- a/src/@data/withGive/resolvers/queries.js
+++ b/src/@data/withGive/resolvers/queries.js
@@ -35,7 +35,7 @@ export const INITIAL_STATE = {
   paymentFailedMessage: '',
   paymentSuccessful: false,
   isSavingPaymentMethod: false,
-  willSavePaymentMethod: true,
+  willSavePaymentMethod: false,
   savedAccountName: '',
   savedPaymentMethodId: null,
 };

--- a/src/@ui/forms/PaymentForm.js
+++ b/src/@ui/forms/PaymentForm.js
@@ -204,7 +204,7 @@ const mapPropsToValues = (props) => {
       paymentMethod !== 'bankAccount' || paymentMethod !== 'creditCard'
         ? 'creditCard'
         : paymentMethod,
-    willSavePaymentMethod: get(props, 'contributions.willSavePaymentMethod', true),
+    willSavePaymentMethod: get(props, 'enforceAccountName') ? true : get(props, 'contributions.willSavePaymentMethod', true),
     ...get(props, 'contributions.bankAccount', { accountType: 'checking' }),
     ...get(props, 'contributions.creditCard', {}),
   };

--- a/src/@ui/forms/SavedPaymentReviewForm.js
+++ b/src/@ui/forms/SavedPaymentReviewForm.js
@@ -180,6 +180,15 @@ const PaymentConfirmationForm = compose(
     onSubmit: async () => {
       try {
         props.isSavingPaymentMethod(true);
+        if (props.person) {
+          await props.setBillingPerson({
+            firstName: props.person.firstName,
+            lastName: props.person.lastName,
+            email: props.person.email,
+            campusId: get(props, 'person.campus.id', null),
+          });
+        }
+
         if (props.contributions.paymentMethod === 'creditCard') {
           await props.validateSingleCardTransaction(); // This seems unnecessary
         }

--- a/src/give/AddAccount/Complete.js
+++ b/src/give/AddAccount/Complete.js
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import { compose, withProps, setPropTypes, defaultProps, branch, renderComponent } from 'recompose';
+import get from 'lodash/get';
+import withGive from '@data/withGive';
+import ActivityIndicator from '@ui/ActivityIndicator';
+
+import Success from './Success';
+import Failure from './Failure';
+
+const PaymentComplete = compose(
+  withGive,
+  withProps(props => ({
+    ...(get(props, 'contributions') || {}),
+  })),
+  setPropTypes({
+    isLoading: PropTypes.bool,
+    paymentFailed: PropTypes.bool,
+    paymentFailedMessage: PropTypes.string,
+    paymentSuccessful: PropTypes.bool,
+  }),
+  defaultProps({
+    isLoading: true,
+    paymentFailed: false,
+    paymentFailedMessage: '',
+    paymentSuccessful: false,
+  }),
+  branch(({ isLoading }) => isLoading, renderComponent(ActivityIndicator)),
+  branch(
+    ({ paymentFailed, paymentSuccessful }) => paymentFailed || !paymentSuccessful,
+    renderComponent(Failure),
+  ),
+)(Success);
+
+export default PaymentComplete;

--- a/src/give/AddAccount/Failure.js
+++ b/src/give/AddAccount/Failure.js
@@ -5,9 +5,10 @@ import PaddedView from '@ui/PaddedView';
 import Icon from '@ui/Icon';
 import { H3, H4, BodyText } from '@ui/typography';
 import { withTheme } from '@ui/theme';
-import { ButtonLink } from '@ui/Button';
+import Button, { ButtonLink } from '@ui/Button';
 import WebBrowser from '@ui/WebBrowser';
 import Paragraph from '@ui/Paragraph';
+import { Link } from '@ui/NativeWebRouter';
 
 const contact = () => WebBrowser.openBrowserAsync('https://rock.newspring.cc/workflows/152?Topic=Stewardship');
 
@@ -42,6 +43,11 @@ const Failure = ({ paymentFailedMessage }) => (
     {paymentFailedMessage ? (
       <Paragraph><BodyText>{paymentFailedMessage}</BodyText></Paragraph>
     ) : null}
+    <Paragraph>
+      <Link pop>
+        <Button title="Try Again" />
+      </Link>
+    </Paragraph>
     <Paragraph>
       <BodyText italic>
         If you would like a member of our customer support team to follow up with you regarding

--- a/src/give/AddAccount/Failure.js
+++ b/src/give/AddAccount/Failure.js
@@ -39,7 +39,7 @@ const Failure = ({ paymentFailedMessage }) => (
   <BackgroundView>
     <ThemedIcon name="circle-outline-x-mark" />
     <Heading>Uh Oh!</Heading>
-    <SubHeading>Looks like there was a problem adding your card.</SubHeading>
+    <SubHeading>Looks like there was a problem adding your payment method.</SubHeading>
     {paymentFailedMessage ? (
       <Paragraph><BodyText>{paymentFailedMessage}</BodyText></Paragraph>
     ) : null}

--- a/src/give/AddAccount/Failure.js
+++ b/src/give/AddAccount/Failure.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from '@ui/styled';
+import PaddedView from '@ui/PaddedView';
+import Icon from '@ui/Icon';
+import { H3, H4, BodyText } from '@ui/typography';
+import { withTheme } from '@ui/theme';
+import { ButtonLink } from '@ui/Button';
+import WebBrowser from '@ui/WebBrowser';
+import Paragraph from '@ui/Paragraph';
+
+const contact = () => WebBrowser.openBrowserAsync('https://rock.newspring.cc/workflows/152?Topic=Stewardship');
+
+const BackgroundView = styled(({ theme }) => ({
+  backgroundColor: theme.colors.background.paper,
+  justifyContent: 'center',
+  alignItems: 'center',
+  paddingTop: theme.sizing.baseUnit * 3,
+}))(PaddedView);
+
+const ThemedIcon = withTheme(({ theme }) => ({
+  size: theme.sizing.baseUnit * 3,
+  fill: theme.colors.alert,
+}))(Icon);
+
+const Heading = styled(({ theme }) => ({
+  color: theme.colors.alert,
+  paddingTop: theme.sizing.baseUnit,
+}))(H3);
+
+const SubHeading = styled(({ theme }) => ({
+  color: theme.colors.text.secondary,
+  paddingBottom: theme.sizing.baseUnit,
+  textAlign: 'center',
+}))(H4);
+
+const Failure = ({ paymentFailedMessage }) => (
+  <BackgroundView>
+    <ThemedIcon name="circle-outline-x-mark" />
+    <Heading>Uh Oh!</Heading>
+    <SubHeading>Looks like there was a problem adding your card.</SubHeading>
+    {paymentFailedMessage ? (
+      <Paragraph><BodyText>{paymentFailedMessage}</BodyText></Paragraph>
+    ) : null}
+    <Paragraph>
+      <BodyText italic>
+        If you would like a member of our customer support team to follow up with you regarding
+        this error, please{' '}
+        <ButtonLink onPress={contact}>contact us</ButtonLink>
+        {' '}and someone will be happy to assist you.
+      </BodyText>
+    </Paragraph>
+  </BackgroundView>
+);
+
+Failure.propTypes = {
+  paymentFailedMessage: PropTypes.string,
+};
+
+export default Failure;

--- a/src/give/AddAccount/PaymentMethodConfirmation.js
+++ b/src/give/AddAccount/PaymentMethodConfirmation.js
@@ -1,19 +1,36 @@
 import React from 'react';
-import PaddedView from '@ui/PaddedView';
+import { compose, mapProps } from 'recompose';
+import { withRouter } from '@ui/NativeWebRouter';
 import BackgroundView from '@ui/BackgroundView';
 import SavedPaymentReviewForm from '@ui/forms/SavedPaymentReviewForm';
+import PaddedView from '@ui/PaddedView';
+import { Title, Row, TinyButton, TinyButtonText } from '../styles';
 
-import { Title } from '../styles';
 
-const PaymentMethodConfirmation = () => (
+const enhance = compose(
+  withRouter,
+  mapProps(props => ({
+    onPressEdit() {
+      props.history.push('address');
+    },
+  })),
+);
+
+const PaymentMethodConfirmation = enhance(({ onPressEdit }) => (
   <BackgroundView>
     <PaddedView>
-      <Title>Review</Title>
+      <Row>
+        <Title>Review</Title>
+        <TinyButton onPress={onPressEdit}>
+          <TinyButtonText>Edit</TinyButtonText>
+        </TinyButton>
+      </Row>
     </PaddedView>
     <SavedPaymentReviewForm
       navigateToOnComplete="done"
     />
   </BackgroundView>
-);
+));
 
 export default PaymentMethodConfirmation;
+

--- a/src/give/AddAccount/index.js
+++ b/src/give/AddAccount/index.js
@@ -9,7 +9,7 @@ import ModalView from '@ui/ModalView';
 import BillingAddress from './BillingAddress';
 import PaymentMethod from './PaymentMethod';
 import PaymentMethodConfirmation from './PaymentMethodConfirmation';
-import Success from './Success';
+import Complete from './Complete';
 
 function lastDirectory(pathname = '') {
   const pathParts = pathname.split('/');
@@ -35,7 +35,7 @@ const Checkout = withRouter(({ match, location }) => (
           <Route exact path={`${match.url}/address`} component={BillingAddress} />
           <Route exact path={`${match.url}/method`} component={PaymentMethod} />
           <Route exact path={`${match.url}/confirm`} component={PaymentMethodConfirmation} />
-          <Route exact path={`${match.url}/done`} component={Success} />
+          <Route exact path={`${match.url}/done`} component={Complete} />
         </Switch>
       </KeyboardAwareScrollView>
     </BackgroundView>

--- a/src/give/Checkout/Failure.js
+++ b/src/give/Checkout/Failure.js
@@ -5,9 +5,10 @@ import PaddedView from '@ui/PaddedView';
 import Icon from '@ui/Icon';
 import { H3, H4, BodyText } from '@ui/typography';
 import { withTheme } from '@ui/theme';
-import { ButtonLink } from '@ui/Button';
+import Button, { ButtonLink } from '@ui/Button';
 import WebBrowser from '@ui/WebBrowser';
 import Paragraph from '@ui/Paragraph';
+import { Link } from '@ui/NativeWebRouter';
 
 const contact = () => WebBrowser.openBrowserAsync('https://rock.newspring.cc/workflows/152?Topic=Stewardship');
 
@@ -42,6 +43,11 @@ const Failure = ({ paymentFailedMessage }) => (
     {paymentFailedMessage ? (
       <Paragraph><BodyText>{paymentFailedMessage}</BodyText></Paragraph>
     ) : null}
+    <Paragraph>
+      <Link pop>
+        <Button title="Try Again" />
+      </Link>
+    </Paragraph>
     <Paragraph>
       <BodyText italic>
         If you would like a member of our customer support team to follow up with you regarding


### PR DESCRIPTION
So there were two issues to solve.

First, the bad credit card actually _wasn't_ being added, we just weren't properly showing an error message.

Second - and the real bug - we were saving some of the state from saving a credit card so if the user tried again, they wouldn't have to re-enter all their information again. When checking out with a valid credit card, the checkout process was reacting to state that said "Save Credit Card with this name" - except the name was the unsuccessful BAD credit card. So this is fixed by explicitly resetting state when starting a _new_ giving transaction.

I made a few other tweaks though:
- Added "Try again" buttons to both failure state screens on giving and adding payment method
- The same bug (but less severe) existed if you went to gave, added a fake CC, then selected a saved credit card to give with. This is fixed by selectively resetting some state whenever you select a new credit card
- A few other minor UI tweaks (like an Edit button on the add payment review screen)

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

