### PR TITLE
Fix Fabric on iOS

### DIFF
--- a/ios/newspring.xcodeproj/project.pbxproj
+++ b/ios/newspring.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 				B563863F1DB9693800A0598C /* Resources */,
 				8D34C7FE3D99F20E5EA1B18A /* [CP] Embed Pods Frameworks */,
 				AA38385B7D8D0854176B72FC /* [CP] Copy Pods Resources */,
+				792C66482088F8E1003E55EC /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -222,6 +223,19 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		792C66482088F8E1003E55EC /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Fabric/run\" 832b942c034afd6e4772120ba045e88211a693ba 042d41e897f444a5d31c47d933496f142302ee4cf6aa1f6a1897b2f12ced6f5f";
 		};
 		8D34C7FE3D99F20E5EA1B18A /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/ios/newspring/AppDelegate.m
+++ b/ios/newspring/AppDelegate.m
@@ -1,6 +1,9 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "AppDelegate.h"
+#import <Branch/Branch.h>
+#import <Fabric/Fabric.h>
+#import <Crashlytics/Crashlytics.h>
 #import "ExpoKit.h"
 #import "EXViewController.h"
 
@@ -14,6 +17,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+    [Fabric with:@[[Crashlytics class], [Branch class]]];
     _window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     _window.backgroundColor = [UIColor whiteColor];
     [[ExpoKit sharedInstance] application:application didFinishLaunchingWithOptions:launchOptions];


### PR DESCRIPTION
I noticed iOS wasn't getting logged in Fabric, looks like the code I added to xcode didn't make it through the pipe. So, I re-added it.

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

