### PR TITLE
Add outbound link tracking

### DIFF
--- a/src/@ui/NativeWebRouter/Link.js
+++ b/src/@ui/NativeWebRouter/Link.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import Touchable from '@ui/Touchable';
 import WebBrowser from '@ui/WebBrowser';
+import { track, events } from '@utils/analytics';
 
 import { matchPath } from './';
 
@@ -64,6 +65,7 @@ export default class Link extends PureComponent {
 
     // handle web links
     if (to && to.indexOf('http') > -1) {
+      track(events.OutboundLink, { to });
       return WebBrowser.openBrowserAsync(to);
     }
 

--- a/src/@utils/analytics/index.js
+++ b/src/@utils/analytics/index.js
@@ -6,6 +6,7 @@ import instance from './instance';
 const AppBecameInactive = 'AppBecameInactive';
 const AppBecameActive = 'AppBecameActive';
 const AppBecameBackgrounded = 'AppBecameBackgrounded';
+const OutboundLink = 'OutboundLink';
 const ScreenView = 'ScreenView';
 const Liked = 'Liked';
 const Shared = 'Shared';
@@ -21,6 +22,7 @@ export const events = {
   AppBecameInactive,
   AppBecameActive,
   AppBecameBackgrounded,
+  OutboundLink,
   ScreenView,
   Liked,
   Shared,


### PR DESCRIPTION
This adds an analytics event for tracking when users open outside links inside of the app....For example: the live stream. Or a link in an article that opens a webview.

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

