### PR TITLE
Fix: Clear order state when adding an account

### DIFF
--- a/src/@data/withGive/createSavePaymentOrder.js
+++ b/src/@data/withGive/createSavePaymentOrder.js
@@ -1,0 +1,47 @@
+import gql from 'graphql-tag';
+import { graphql } from 'react-apollo';
+import Client from '@data/Client';
+import { QUERY as contributionsQuery } from './withContributions';
+import getOrderDetails from './selectors/getOrderDetails';
+import { INITIAL_STATE } from './resolvers/queries';
+
+export const MUTATION = gql`
+  mutation order($data: String!, $id: ID, $instant: Boolean) {
+    order: createOrder(data: $data, id: $id, instant: $instant) {
+      url
+      error
+      success
+      code
+    }
+  }
+`;
+
+export default graphql(MUTATION, {
+  props: ({ mutate }) => ({
+    createSavePaymentOrder() {
+      const { contributions } = Client.readQuery({
+        query: contributionsQuery,
+      });
+
+      const state = {
+        ...contributions,
+        contributions: INITIAL_STATE.contributions,
+        frequencyId: INITIAL_STATE.frequencyId,
+        startDate: INITIAL_STATE.startDate,
+      };
+
+      const orderDetails = getOrderDetails(state);
+      if (orderDetails.savedAccount) delete orderDetails.billing;
+      const data = JSON.stringify(orderDetails);
+
+      const isInstant = state.paymentMethod === 'savedPaymentMethod' && state.frequencyId !== 'today';
+      return mutate({
+        variables: {
+          data,
+          id: null,
+          instant: isInstant,
+        },
+      });
+    },
+  }),
+});

--- a/src/@data/withGive/index.js
+++ b/src/@data/withGive/index.js
@@ -7,6 +7,7 @@ import setBillingPerson from './setBillingPerson';
 import setBillingAddress from './setBillingAddress';
 import withContributions from './withContributions';
 import createOrder from './createOrder';
+import createSavedPaymentOrder from './createSavePaymentOrder';
 import setCreditCard from './setCreditCard';
 import setBankAccount from './setBankAccount';
 import setPaymentMethod from './setPaymentMethod';
@@ -30,6 +31,7 @@ export default compose(
   setBillingPerson,
   setBillingAddress,
   createOrder,
+  createSavedPaymentOrder,
   setCreditCard,
   setBankAccount,
   setPaymentMethod,

--- a/src/@ui/CardTile/__snapshots__/CardTile.tests.js.snap
+++ b/src/@ui/CardTile/__snapshots__/CardTile.tests.js.snap
@@ -896,7 +896,7 @@ exports[`the Card component should render card details with date 1`] = `
               }
             }
           >
-            32y
+            33y
           </Text>
         </View>
       </View>

--- a/src/@ui/forms/SavedPaymentReviewForm.js
+++ b/src/@ui/forms/SavedPaymentReviewForm.js
@@ -192,7 +192,7 @@ const PaymentConfirmationForm = compose(
         if (props.contributions.paymentMethod === 'creditCard') {
           await props.validateSingleCardTransaction(); // This seems unnecessary
         }
-        const createOrderResponse = await props.createOrder();
+        const createOrderResponse = await props.createSavePaymentOrder();
         const order = get(createOrderResponse, 'data.order', {});
         const token = order.url.split('/').pop();
         await props.postPayment(order.url);

--- a/src/give/AddAccount/index.js
+++ b/src/give/AddAccount/index.js
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { compose } from 'recompose';
 import KeyboardAwareScrollView from '@ui/KeyboardAwareScrollView';
 import { Switch, Route, withRouter } from '@ui/NativeWebRouter';
 import Header from '@ui/Header';
 import BackgroundView from '@ui/BackgroundView';
 import Progress from '@ui/Progress';
 import ModalView from '@ui/ModalView';
+
+import withGive from '@data/withGive';
 
 import BillingAddress from './BillingAddress';
 import PaymentMethod from './PaymentMethod';
@@ -25,21 +29,46 @@ const progressForLocation = ({ pathname }) => {
   return step / 3; // 3 steps == start the user with progress
 };
 
-const Checkout = withRouter(({ match, location }) => (
-  <ModalView backTo="/give" onBackReplace>
-    <BackgroundView>
-      <Header titleText="Add Account" backButton />
-      <Progress progress={progressForLocation(location)} />
-      <KeyboardAwareScrollView>
-        <Switch>
-          <Route exact path={`${match.url}/address`} component={BillingAddress} />
-          <Route exact path={`${match.url}/method`} component={PaymentMethod} />
-          <Route exact path={`${match.url}/confirm`} component={PaymentMethodConfirmation} />
-          <Route exact path={`${match.url}/done`} component={Complete} />
-        </Switch>
-      </KeyboardAwareScrollView>
-    </BackgroundView>
-  </ModalView>
-));
+const enhance = compose(
+  withRouter,
+  withGive,
+);
 
-export default Checkout;
+class Checkout extends PureComponent {
+  static propTypes = {
+    match: PropTypes.shape({
+      url: PropTypes.string,
+    }),
+    location: PropTypes.shape({
+      pathname: PropTypes.string,
+    }),
+    resetContributions: PropTypes.func.isRequired,
+  };
+
+  componentWillMount() {
+    this.props.resetContributions();
+  }
+
+  render() {
+    const { match, location } = this.props;
+    return (
+      <ModalView backTo="/give" onBackReplace>
+        <BackgroundView>
+          <Header titleText="Add Account" backButton />
+          <Progress progress={progressForLocation(location)} />
+          <KeyboardAwareScrollView>
+            <Switch>
+              <Route exact path={`${match.url}/address`} component={BillingAddress} />
+              <Route exact path={`${match.url}/method`} component={PaymentMethod} />
+              <Route exact path={`${match.url}/confirm`} component={PaymentMethodConfirmation} />
+              <Route exact path={`${match.url}/done`} component={Complete} />
+            </Switch>
+          </KeyboardAwareScrollView>
+        </BackgroundView>
+      </ModalView>
+    );
+  }
+}
+
+
+export default enhance(Checkout);

--- a/src/give/AddAccount/index.js
+++ b/src/give/AddAccount/index.js
@@ -1,14 +1,10 @@
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import { compose } from 'recompose';
+import React from 'react';
 import KeyboardAwareScrollView from '@ui/KeyboardAwareScrollView';
 import { Switch, Route, withRouter } from '@ui/NativeWebRouter';
 import Header from '@ui/Header';
 import BackgroundView from '@ui/BackgroundView';
 import Progress from '@ui/Progress';
 import ModalView from '@ui/ModalView';
-
-import withGive from '@data/withGive';
 
 import BillingAddress from './BillingAddress';
 import PaymentMethod from './PaymentMethod';
@@ -29,46 +25,21 @@ const progressForLocation = ({ pathname }) => {
   return step / 3; // 3 steps == start the user with progress
 };
 
-const enhance = compose(
-  withRouter,
-  withGive,
-);
+const Checkout = withRouter(({ match, location }) => (
+  <ModalView backTo="/give" onBackReplace>
+    <BackgroundView>
+      <Header titleText="Add Account" backButton />
+      <Progress progress={progressForLocation(location)} />
+      <KeyboardAwareScrollView>
+        <Switch>
+          <Route exact path={`${match.url}/address`} component={BillingAddress} />
+          <Route exact path={`${match.url}/method`} component={PaymentMethod} />
+          <Route exact path={`${match.url}/confirm`} component={PaymentMethodConfirmation} />
+          <Route exact path={`${match.url}/done`} component={Complete} />
+        </Switch>
+      </KeyboardAwareScrollView>
+    </BackgroundView>
+  </ModalView>
+));
 
-class Checkout extends PureComponent {
-  static propTypes = {
-    match: PropTypes.shape({
-      url: PropTypes.string,
-    }),
-    location: PropTypes.shape({
-      pathname: PropTypes.string,
-    }),
-    resetContributions: PropTypes.func.isRequired,
-  };
-
-  componentWillMount() {
-    this.props.resetContributions();
-  }
-
-  render() {
-    const { match, location } = this.props;
-    return (
-      <ModalView backTo="/give" onBackReplace>
-        <BackgroundView>
-          <Header titleText="Add Account" backButton />
-          <Progress progress={progressForLocation(location)} />
-          <KeyboardAwareScrollView>
-            <Switch>
-              <Route exact path={`${match.url}/address`} component={BillingAddress} />
-              <Route exact path={`${match.url}/method`} component={PaymentMethod} />
-              <Route exact path={`${match.url}/confirm`} component={PaymentMethodConfirmation} />
-              <Route exact path={`${match.url}/done`} component={Complete} />
-            </Switch>
-          </KeyboardAwareScrollView>
-        </BackgroundView>
-      </ModalView>
-    );
-  }
-}
-
-
-export default enhance(Checkout);
+export default Checkout;


### PR DESCRIPTION
We recently stopped reseting order state when getting an error in the checkout process so that you could go back and fix any issues. This is causing real orders to be created when adding an account if you previously tried to give but were unsuccessful. This should fix that by clearing order state when you go to add an account.

Essentially just adds a `resetContributions` call to `componentDidMount` on the `AddAccount` component.

Fixes [issue-number]

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

