### PR TITLE
Secondary Nav Loading Fix

### DIFF
--- a/src/@ui/SecondaryNav/index.js
+++ b/src/@ui/SecondaryNav/index.js
@@ -27,14 +27,16 @@ const SecondaryNav = ({
   onBackPress,
   children,
   onBackReplace,
-}) => (
-  <TabBar>
-    {backButton ? (
-      <Link pop to={backTo} icon={backButtonIcon} onPress={onBackPress} replace={onBackReplace} />
-    ) : null}
-    {children}
-  </TabBar>
-);
+  isLoading = false,
+}) =>
+  !isLoading && (
+    <TabBar>
+      {backButton ? (
+        <Link pop to={backTo} icon={backButtonIcon} onPress={onBackPress} replace={onBackReplace} />
+      ) : null}
+      {children}
+    </TabBar>
+  );
 
 SecondaryNav.propTypes = {
   backButton: PropTypes.bool,
@@ -43,6 +45,7 @@ SecondaryNav.propTypes = {
   onBackPress: PropTypes.func,
   backTo: PropTypes.string,
   onBackReplace: PropTypes.bool,
+  isLoading: PropTypes.bool,
 };
 
 export default SecondaryNav;

--- a/src/@ui/SecondaryNav/index.js
+++ b/src/@ui/SecondaryNav/index.js
@@ -29,14 +29,14 @@ const SecondaryNav = ({
   onBackReplace,
   isLoading = false,
 }) =>
-  !isLoading && (
+  (!isLoading ? (
     <TabBar>
       {backButton ? (
         <Link pop to={backTo} icon={backButtonIcon} onPress={onBackPress} replace={onBackReplace} />
       ) : null}
       {children}
     </TabBar>
-  );
+  ) : null);
 
 SecondaryNav.propTypes = {
   backButton: PropTypes.bool,

--- a/src/articles/Single.js
+++ b/src/articles/Single.js
@@ -20,38 +20,38 @@ const enhance = compose(
 
 const ShareLink = withArticle(Share);
 
-const ArticleSingle = enhance(({
-  content: {
-    authors = [],
-    title = '',
+const ArticleSingle = enhance(
+  ({
     content: {
-      isLiked,
-      body,
-      tags,
-      ...otherContentProps
+      authors = [],
+      title = '',
+      content: {
+        isLiked, body, tags, ...otherContentProps
+      } = {},
     } = {},
-  } = { },
-  id,
-  isLoading,
-}) => (
-  <BackgroundView>
-    <Header titleText="Article" backButton />
-    <ScrollView>
-      <ContentView isLoading={isLoading} {...otherContentProps}>
-        <Title>{title}</Title>
-        <ByLine authors={authors} />
-        <HTMLView>{body}</HTMLView>
-      </ContentView>
-      { // Don't render till data is ready. Consider adding placeholder views for the content above.
+    id,
+    isLoading,
+  }) => (
+    <BackgroundView>
+      <Header titleText="Article" backButton />
+      <ScrollView>
+        <ContentView isLoading={isLoading} {...otherContentProps}>
+          <Title>{title}</Title>
+          <ByLine authors={authors} />
+          <HTMLView>{body}</HTMLView>
+        </ContentView>
+        {// Don't render till data is ready.
+        // Consider adding placeholder views for the content above.
         !isLoading && <RelatedContent tags={tags} excludedIds={[id]} />}
-    </ScrollView>
-    <MediaQuery maxWidth="md">
-      <SecondaryNav>
-        <ShareLink id={id} />
-        <Like id={id} isLiked={isLiked} />
-      </SecondaryNav>
-    </MediaQuery>
-  </BackgroundView>
-));
+      </ScrollView>
+      <MediaQuery maxWidth="md">
+        <SecondaryNav isLoading={isLoading}>
+          <ShareLink id={id} />
+          <Like id={id} isLiked={isLiked} />
+        </SecondaryNav>
+      </MediaQuery>
+    </BackgroundView>
+  ),
+);
 
 export default ArticleSingle;

--- a/src/group-finder/GroupSingle.js
+++ b/src/group-finder/GroupSingle.js
@@ -105,7 +105,8 @@ const GroupSingle = enhance(
       ageRange,
       campus = {},
       tags = [],
-      locations = [], // schedule { description } // { location { city, state, latitude, longitude } }
+      locations = [], // schedule { description }
+      // { location { city, state, latitude, longitude } }
       members = [], //   role // {
       //   person { id, photo, firstName, nickName, lastName }
       // }

--- a/src/group-finder/GroupSingle.js
+++ b/src/group-finder/GroupSingle.js
@@ -30,16 +30,9 @@ const FlexedLeft = styled({ flex: 1 })(Left);
 
 const rockUrl = Settings.APP_ROCK_URL || 'https://rock.newspring.cc/'; // todo
 
-const enhance = compose(
-  pure,
-  mapProps(({ match: { params: { id } } }) => ({ id })),
-  withGroupInfo,
-);
+const enhance = compose(pure, mapProps(({ match: { params: { id } } }) => ({ id })), withGroupInfo);
 
-const ShareLink = compose(
-  withGroupInfo,
-  mapProps(({ group } = {}) => ({ content: group })),
-)(Share);
+const ShareLink = compose(withGroupInfo, mapProps(({ group } = {}) => ({ content: group })))(Share);
 
 const StyledImage = styled({
   width: '100%',
@@ -68,12 +61,14 @@ const GroupFindCTA = styled({
   alignItems: 'center',
 })(PaddedView);
 
-const leadersLoadingState = [{
-  person: {
-    id: 'loading',
-    photo: null,
+const leadersLoadingState = [
+  {
+    person: {
+      id: 'loading',
+      photo: null,
+    },
   },
-}];
+];
 
 const handleGroupContact = ({ guid, loginParam }) => {
   WebBrowser.openBrowserAsync(`${rockUrl}Workflows/304?Group=${guid}${loginParam}`);
@@ -95,162 +90,192 @@ GroupInfo.propTypes = {
 const isCurrentPersonLeader = (person, leaders) =>
   person && Array.isArray(leaders) && leaders.filter(x => x.person.id === person.id).length;
 
-const GroupSingle = enhance(({
-  id,
-  group: {
-    photo = null,
-    name,
-    // name
-    guid,
-    entityId,
-    type,
-    demographic,
-    description,
-    kidFriendly,
-    ageRange,
-    campus = {},
-    tags = [],
-    locations = [], // { location { city, state, latitude, longitude } }
-    // schedule { description }
-    members = [], // {
-    //   role
-    //   person { id, photo, firstName, nickName, lastName }
-    // }
-    // groupType
-    isLiked,
-  } = {},
-  person,
-  isLoading,
-}) => {
-  const leaders = members.filter(x => x.role.toLowerCase() === 'leader');
-  const loginParam = person ? person.impersonationParameter : '';
-  const isLeader = isCurrentPersonLeader(person, leaders);
-  return (
-    <BackgroundView>
-      <Meta title={name} image={photo} description={description} id={id} />
-      <Header titleText="Group Profile" backButton />
-      <FlexedSideBySideView>
-        <FlexedLeft>
-          <ScrollView>
-            <StyledImage source={{ url: photo }} />
-            <Card isLoading={isLoading}>
-              <PaddedView>
-                <H3>{name}</H3>
-              </PaddedView>
-              <PaddedView vertical={false}>
-                <Label>Group Leaders</Label>
-                <H5>{leaders.map(leader => `${leader.person.firstName} ${leader.person.lastName}`).join(', ')}</H5>
-                <AvatarList>
-                  {(isLoading ? leadersLoadingState : leaders).map(leader => (
-                    <Avatar key={leader.person.id} source={{ url: leader.person.photo }} size="medium" />
-                  ))}
-                </AvatarList>
-              </PaddedView>
-            </Card>
-
-            <Card isLoading={isLoading}>
-              <PaddedView>
-                <CenteredSideBySideView>
-                  <AdTitle>#TheseAreMyPeople</AdTitle>
-                  {isLeader ? (
-                    <Button title="Manage" bordered onPress={() => WebBrowser.openBrowserAsync(`${rockUrl}page/521?GroupId=${entityId}&${loginParam}`)} />
-                  ) : (
-                    <Button title="Contact" bordered onPress={() => handleGroupContact({ guid, loginParam })} />
-                  )}
-                </CenteredSideBySideView>
-              </PaddedView>
-            </Card>
-
-            <Card isLoading={isLoading}>
-              <PaddedView>
-                <H5>Group Details</H5>
-                {(() => {
-                  const loc = locations[0];
-                  if (!loc) return null;
-                  return <GroupInfo label="Address" info={`${loc.location.city}, ${loc.location.state}`} />;
-                })()}
-                {(() => {
-                  if (!campus || !campus.name) return null;
-                  return <GroupInfo label="Campus" info={campus.name} />;
-                })()}
-                {(() => {
-                  let info = kidFriendly ? 'Children Welcome' : 'Adults Only';
-                  if (ageRange) info += `, ${ageRange[0]} - ${ageRange[1]}`;
-                  return <GroupInfo label="Information" info={info} />;
-                })()}
-              </PaddedView>
-            </Card>
-
-            <Card isLoading={isLoading}>
-              <PaddedView>
-                <H5>More Information</H5>
-                <GroupInfoContainer>
-                  <Label>Description</Label>
-                  <BodyText>{description}</BodyText>
-                </GroupInfoContainer>
-
-                <GroupInfoContainer>
-                  <Label>Members</Label>
+const GroupSingle = enhance(
+  ({
+    id,
+    group: {
+      photo = null,
+      name, // name
+      guid,
+      entityId,
+      type,
+      demographic,
+      description,
+      kidFriendly,
+      ageRange,
+      campus = {},
+      tags = [],
+      locations = [], // schedule { description } // { location { city, state, latitude, longitude } }
+      members = [], //   role // {
+      //   person { id, photo, firstName, nickName, lastName }
+      // }
+      // groupType
+      isLiked,
+    } = {},
+    person,
+    isLoading,
+  }) => {
+    const leaders = members.filter(x => x.role.toLowerCase() === 'leader');
+    const loginParam = person ? person.impersonationParameter : '';
+    const isLeader = isCurrentPersonLeader(person, leaders);
+    return (
+      <BackgroundView>
+        <Meta title={name} image={photo} description={description} id={id} />
+        <Header titleText="Group Profile" backButton />
+        <FlexedSideBySideView>
+          <FlexedLeft>
+            <ScrollView>
+              <StyledImage source={{ url: photo }} />
+              <Card isLoading={isLoading}>
+                <PaddedView>
+                  <H3>{name}</H3>
+                </PaddedView>
+                <PaddedView vertical={false}>
+                  <Label>Group Leaders</Label>
+                  <H5>
+                    {leaders
+                      .map(leader => `${leader.person.firstName} ${leader.person.lastName}`)
+                      .join(', ')}
+                  </H5>
                   <AvatarList>
-                    {members.filter(x => x.person && x.person.photo).map(member => (
-                      <Avatar key={member.person.id} source={{ url: member.person.photo }} size="small" />
+                    {(isLoading ? leadersLoadingState : leaders).map(leader => (
+                      <Avatar
+                        key={leader.person.id}
+                        source={{ url: leader.person.photo }}
+                        size="medium"
+                      />
                     ))}
                   </AvatarList>
-                </GroupInfoContainer>
+                </PaddedView>
+              </Card>
 
-                <GroupInfoContainer>
-                  <Label>Tags</Label>
-                  <ChipList>
-                    {tags.map(tag => (
-                      <Chip key={tag.id} title={tag.value} />
-                    ))}
-                    {(() => {
-                      if (!type || type === 'Interests') return null;
-                      return <Chip title={type} />;
-                    })()}
-                    {(() => {
-                      if (!kidFriendly) return null;
-                      return <Chip title={'Kid Friendly'} />;
-                    })()}
-                    {(() => {
-                      if (!demographic) return null;
-                      return <Chip title={demographic} />;
-                    })()}
-                  </ChipList>
-                </GroupInfoContainer>
-              </PaddedView>
-            </Card>
+              <Card isLoading={isLoading}>
+                <PaddedView>
+                  <CenteredSideBySideView>
+                    <AdTitle>#TheseAreMyPeople</AdTitle>
+                    {isLeader ? (
+                      <Button
+                        title="Manage"
+                        bordered
+                        onPress={() =>
+                          WebBrowser.openBrowserAsync(
+                            `${rockUrl}page/521?GroupId=${entityId}&${loginParam}`,
+                          )
+                        }
+                      />
+                    ) : (
+                      <Button
+                        title="Contact"
+                        bordered
+                        onPress={() => handleGroupContact({ guid, loginParam })}
+                      />
+                    )}
+                  </CenteredSideBySideView>
+                </PaddedView>
+              </Card>
 
-            <Card>
-              <GroupFindCTA>
-                <AdTitle>Looking for another group?</AdTitle>
-                <Link component={Button} to="/groups" pop title="Find A Group" type="default" />
-              </GroupFindCTA>
-            </Card>
-          </ScrollView>
-        </FlexedLeft>
-        {Platform.OS === 'web' ? (
-          <MediaQuery minWidth="md">
-            <Right>
-              <Map
-                groups={[{
-                  locations,
-                  id,
-                }]}
-                linkToGroup={false}
-              />
-            </Right>
-          </MediaQuery>
-        ) : null}
-      </FlexedSideBySideView>
-      <MediaQuery maxWidth="md">
-        <SecondaryNav>
-          <ShareLink id={id} />
-          <Like id={id} isLiked={isLiked} />
-        </SecondaryNav>
-      </MediaQuery>
-    </BackgroundView>
-  );
-});
+              <Card isLoading={isLoading}>
+                <PaddedView>
+                  <H5>Group Details</H5>
+                  {(() => {
+                    const loc = locations[0];
+                    if (!loc) return null;
+                    return (
+                      <GroupInfo
+                        label="Address"
+                        info={`${loc.location.city}, ${loc.location.state}`}
+                      />
+                    );
+                  })()}
+                  {(() => {
+                    if (!campus || !campus.name) return null;
+                    return <GroupInfo label="Campus" info={campus.name} />;
+                  })()}
+                  {(() => {
+                    let info = kidFriendly ? 'Children Welcome' : 'Adults Only';
+                    if (ageRange) info += `, ${ageRange[0]} - ${ageRange[1]}`;
+                    return <GroupInfo label="Information" info={info} />;
+                  })()}
+                </PaddedView>
+              </Card>
+
+              <Card isLoading={isLoading}>
+                <PaddedView>
+                  <H5>More Information</H5>
+                  <GroupInfoContainer>
+                    <Label>Description</Label>
+                    <BodyText>{description}</BodyText>
+                  </GroupInfoContainer>
+
+                  <GroupInfoContainer>
+                    <Label>Members</Label>
+                    <AvatarList>
+                      {members
+                        .filter(x => x.person && x.person.photo)
+                        .map(member => (
+                          <Avatar
+                            key={member.person.id}
+                            source={{ url: member.person.photo }}
+                            size="small"
+                          />
+                        ))}
+                    </AvatarList>
+                  </GroupInfoContainer>
+
+                  <GroupInfoContainer>
+                    <Label>Tags</Label>
+                    <ChipList>
+                      {tags.map(tag => <Chip key={tag.id} title={tag.value} />)}
+                      {(() => {
+                        if (!type || type === 'Interests') return null;
+                        return <Chip title={type} />;
+                      })()}
+                      {(() => {
+                        if (!kidFriendly) return null;
+                        return <Chip title={'Kid Friendly'} />;
+                      })()}
+                      {(() => {
+                        if (!demographic) return null;
+                        return <Chip title={demographic} />;
+                      })()}
+                    </ChipList>
+                  </GroupInfoContainer>
+                </PaddedView>
+              </Card>
+
+              <Card>
+                <GroupFindCTA>
+                  <AdTitle>Looking for another group?</AdTitle>
+                  <Link component={Button} to="/groups" pop title="Find A Group" type="default" />
+                </GroupFindCTA>
+              </Card>
+            </ScrollView>
+          </FlexedLeft>
+          {Platform.OS === 'web' ? (
+            <MediaQuery minWidth="md">
+              <Right>
+                <Map
+                  groups={[
+                    {
+                      locations,
+                      id,
+                    },
+                  ]}
+                  linkToGroup={false}
+                />
+              </Right>
+            </MediaQuery>
+          ) : null}
+        </FlexedSideBySideView>
+        <MediaQuery maxWidth="md">
+          <SecondaryNav isLoading={isLoading}>
+            <ShareLink id={id} />
+            <Like id={id} isLiked={isLiked} />
+          </SecondaryNav>
+        </MediaQuery>
+      </BackgroundView>
+    );
+  },
+);
 
 export default GroupSingle;

--- a/src/music/Playlist.js
+++ b/src/music/Playlist.js
@@ -16,52 +16,48 @@ const enhance = compose(
   withNowPlaying,
   pure,
   withProps(({ setNowPlaying, content, id }) => ({
-    setNowPlaying: track => setNowPlaying({
-      id,
-      playlist: { ...content.content, title: content.title },
-      currentTrack: track,
-    }),
+    setNowPlaying: track =>
+      setNowPlaying({
+        id,
+        playlist: { ...content.content, title: content.title },
+        currentTrack: track,
+      }),
   })),
 );
 
 const ShareLink = withPlaylist(Share);
 
-const Playlist = enhance(({
-  id,
-  content: {
-    title,
-    content: {
-      isLiked,
-      images = [],
-      tracks = [],
-    } = {},
-  } = { },
-  isLoading,
-  setNowPlaying,
-}) => (
-  <BackgroundView>
-    <Header titleText="Music" backButton />
-    <TracksList
-      isLoading={isLoading}
-      tracks={tracks}
-      onTrackPress={setNowPlaying}
-      trackEllipsisLink={({ title: track }) => `/music/${id}/${encodeURIComponent(track)}`}
-      ListHeaderComponent={
-        <AlbumView
-          isLoading={isLoading}
-          title={title}
-          artist="NewSpring"
-          albumImage={getAlbumImageSource(images)}
-          blurredImage={getBlurredImageSource(images)}
-        />
-      }
-    />
-    <MediaQuery maxWidth="md">
-      <SecondaryNav>
-        <ShareLink id={id} />
-        <Like id={id} isLiked={isLiked} />
-      </SecondaryNav>
-    </MediaQuery>
-  </BackgroundView>
-));
+const Playlist = enhance(
+  ({
+    id,
+    content: { title, content: { isLiked, images = [], tracks = [] } = {} } = {},
+    isLoading,
+    setNowPlaying,
+  }) => (
+    <BackgroundView>
+      <Header titleText="Music" backButton />
+      <TracksList
+        isLoading={isLoading}
+        tracks={tracks}
+        onTrackPress={setNowPlaying}
+        trackEllipsisLink={({ title: track }) => `/music/${id}/${encodeURIComponent(track)}`}
+        ListHeaderComponent={
+          <AlbumView
+            isLoading={isLoading}
+            title={title}
+            artist="NewSpring"
+            albumImage={getAlbumImageSource(images)}
+            blurredImage={getBlurredImageSource(images)}
+          />
+        }
+      />
+      <MediaQuery maxWidth="md">
+        <SecondaryNav isLoading={isLoading}>
+          <ShareLink id={id} />
+          <Like id={id} isLiked={isLiked} />
+        </SecondaryNav>
+      </MediaQuery>
+    </BackgroundView>
+  ),
+);
 export default Playlist;

--- a/src/news/Single.js
+++ b/src/news/Single.js
@@ -20,35 +20,33 @@ const enhance = compose(
 
 const ShareLink = withNewsStory(Share);
 
-const NewsSingle = enhance(({
-  id,
-  content: {
-    authors = [],
-    title = '',
+const NewsSingle = enhance(
+  ({
+    id,
     content: {
-      isLiked,
-      body,
-      ...otherContentProps
+      authors = [],
+      title = '',
+      content: { isLiked, body, ...otherContentProps } = {},
     } = {},
-  } = { },
-  isLoading,
-}) => (
-  <BackgroundView>
-    <Header titleText="News" backButton />
-    <ScrollView>
-      <ContentView isLoading={isLoading} {...otherContentProps}>
-        <Title>{startCase(toLower(title))}</Title>
-        <ByLine authors={authors} />
-        <HTMLView>{body}</HTMLView>
-      </ContentView>
-    </ScrollView>
-    <MediaQuery maxWidth="md">
-      <SecondaryNav>
-        <ShareLink id={id} />
-        <Like id={id} isLiked={isLiked} />
-      </SecondaryNav>
-    </MediaQuery>
-  </BackgroundView>
-));
+    isLoading,
+  }) => (
+    <BackgroundView>
+      <Header titleText="News" backButton />
+      <ScrollView>
+        <ContentView isLoading={isLoading} {...otherContentProps}>
+          <Title>{startCase(toLower(title))}</Title>
+          <ByLine authors={authors} />
+          <HTMLView>{body}</HTMLView>
+        </ContentView>
+      </ScrollView>
+      <MediaQuery maxWidth="md">
+        <SecondaryNav isLoading={isLoading}>
+          <ShareLink id={id} />
+          <Like id={id} isLiked={isLiked} />
+        </SecondaryNav>
+      </MediaQuery>
+    </BackgroundView>
+  ),
+);
 
 export default NewsSingle;

--- a/src/series/Sermon.js
+++ b/src/series/Sermon.js
@@ -71,7 +71,7 @@ const Sermon = enhance(
         </ContentView>
         <HorizontalTileFeed content={children} isLoading={isLoading} showTileMeta />
       </ScrollView>
-      <SecondaryNav>
+      <SecondaryNav isLoading={isLoading}>
         <ShareLink id={id} />
         <Like id={id} isLiked={isLiked} />
       </SecondaryNav>

--- a/src/series/Single.js
+++ b/src/series/Single.js
@@ -48,56 +48,55 @@ const StyledButton = styled(({ theme }) => ({
   marginBottom: theme.sizing.baseUnit,
 }))(Button);
 
-const SeriesSingle = enhance(({
-  content: {
+const SeriesSingle = enhance(
+  ({
     content: {
-      isLiked,
-      video,
-      isLight = true,
-      description,
-      tags,
-      colors,
-      ...otherContentProps
+      content: {
+        isLiked,
+        video,
+        isLight = true,
+        description,
+        tags,
+        colors,
+        ...otherContentProps
+      } = {},
+      children,
     } = {},
-    children,
-  } = { },
-  id,
-  history,
-  isLoading,
-  theme,
-}) => (
-  <BackgroundView>
-    <Header
-      titleText="Series"
-      backButton
-      barStyle={isLight ? 'dark-content' : 'light-content'}
-    />
-    <ScrollView>
-      <ContentView
-        isLoading={isLoading}
-        imageOverlayColor={(colors && colors.length) ? `#${get(colors, '[0].value')}` : null}
-        {...otherContentProps}
-      >
-        {(video && video.embedUrl) ? (
-          <StyledButton onPress={() => history.push(`/series/${id}/trailer`)} type={'ghost'} bordered>
-            <Icon name="play" size={theme.helpers.rem(0.875)} fill={theme.colors.text.primary} />
-            <H6>{' '}Watch The Trailer</H6>{/* NOTE: empty string pads the text from the icon */}
-          </StyledButton>
-        ) : null}
-        <HTMLView>{description}</HTMLView>
-      </ContentView>
-      <HorizontalTileFeed
-        content={children}
-        isLoading={isLoading}
-        showTileMeta
-      />
-      { // Don't render till data is ready. Consider adding placeholder views for the content above.
+    id,
+    history,
+    isLoading,
+    theme,
+  }) => (
+    <BackgroundView>
+      <Header titleText="Series" backButton barStyle={isLight ? 'dark-content' : 'light-content'} />
+      <ScrollView>
+        <ContentView
+          isLoading={isLoading}
+          imageOverlayColor={colors && colors.length ? `#${get(colors, '[0].value')}` : null}
+          {...otherContentProps}
+        >
+          {video && video.embedUrl ? (
+            <StyledButton
+              onPress={() => history.push(`/series/${id}/trailer`)}
+              type={'ghost'}
+              bordered
+            >
+              <Icon name="play" size={theme.helpers.rem(0.875)} fill={theme.colors.text.primary} />
+              <H6> Watch The Trailer</H6>
+              {/* NOTE: empty string pads the text from the icon */}
+            </StyledButton>
+          ) : null}
+          <HTMLView>{description}</HTMLView>
+        </ContentView>
+        <HorizontalTileFeed content={children} isLoading={isLoading} showTileMeta />
+        {// Don't render till data is ready. Consider adding placeholder views for the content above.
         !isLoading && <RelatedContent tags={tags} excludedIds={[id]} />}
-    </ScrollView>
-    <SecondaryNav>
-      <ShareLink id={id} />
-      <Like id={id} isLiked={isLiked} />
-    </SecondaryNav>
-  </BackgroundView>
-));
+      </ScrollView>
+      <SecondaryNav isLoading={isLoading}>
+        <ShareLink id={id} />
+        <Like id={id} isLiked={isLiked} />
+      </SecondaryNav>
+    </BackgroundView>
+  ),
+);
 export default SeriesSingle;

--- a/src/series/Single.js
+++ b/src/series/Single.js
@@ -89,7 +89,8 @@ const SeriesSingle = enhance(
           <HTMLView>{description}</HTMLView>
         </ContentView>
         <HorizontalTileFeed content={children} isLoading={isLoading} showTileMeta />
-        {// Don't render till data is ready. Consider adding placeholder views for the content above.
+        {// Don't render till data is ready.
+        // Consider adding placeholder views for the content above.
         !isLoading && <RelatedContent tags={tags} excludedIds={[id]} />}
       </ScrollView>
       <SecondaryNav isLoading={isLoading}>

--- a/src/stories/Single.js
+++ b/src/stories/Single.js
@@ -21,36 +21,35 @@ const enhance = compose(
 
 const ShareLink = withStory(Share);
 
-const StorySingle = enhance(({
-  content: {
-    authors = [],
-    title = '',
+const StorySingle = enhance(
+  ({
     content: {
-      isLiked,
-      body,
-      tags,
-      ...otherContentProps
+      authors = [],
+      title = '',
+      content: {
+        isLiked, body, tags, ...otherContentProps
+      } = {},
     } = {},
-  } = { },
-  id,
-  isLoading,
-}) => (
-  <BackgroundView>
-    <Header titleText="Story" backButton />
-    <ScrollView>
-      <ContentView isLoading={isLoading} {...otherContentProps}>
-        <Title>{startCase(toLower(title))}</Title>
-        <ByLine authors={authors} />
-        <HTMLView>{body}</HTMLView>
-      </ContentView>
-      <RelatedContent tags={tags} excludedIds={[id]} />
-    </ScrollView>
-    <MediaQuery maxWidth="md">
-      <SecondaryNav>
-        <ShareLink id={id} />
-        <Like id={id} isLiked={isLiked} />
-      </SecondaryNav>
-    </MediaQuery>
-  </BackgroundView>
-));
+    id,
+    isLoading,
+  }) => (
+    <BackgroundView>
+      <Header titleText="Story" backButton />
+      <ScrollView>
+        <ContentView isLoading={isLoading} {...otherContentProps}>
+          <Title>{startCase(toLower(title))}</Title>
+          <ByLine authors={authors} />
+          <HTMLView>{body}</HTMLView>
+        </ContentView>
+        <RelatedContent tags={tags} excludedIds={[id]} />
+      </ScrollView>
+      <MediaQuery maxWidth="md">
+        <SecondaryNav isLoading={isLoading}>
+          <ShareLink id={id} />
+          <Like id={id} isLiked={isLiked} />
+        </SecondaryNav>
+      </MediaQuery>
+    </BackgroundView>
+  ),
+);
 export default StorySingle;

--- a/src/studies/Entry/index.js
+++ b/src/studies/Entry/index.js
@@ -26,7 +26,7 @@ const enhance = compose(
     return { colors };
   }),
   withThemeMixin(({ colors }) => {
-    const theme = { };
+    const theme = {};
     if (colors && colors.length) {
       const primary = `#${colors[0].value}`;
       theme.colors = {
@@ -41,58 +41,57 @@ const enhance = compose(
 
 const ShareLink = withStudyEntry(Share);
 
-const Study = enhance(({
-  id,
-  content: {
-    title,
-    parent = {},
+const Study = enhance(
+  ({
+    id,
     content: {
-      isLiked,
-      body,
-      scripture = [],
-      ...otherContentProps
+      title,
+      parent = {},
+      content: {
+        isLiked, body, scripture = [], ...otherContentProps
+      } = {},
     } = {},
-  } = {},
-  isLoading,
-}) => {
-  const hasScripture = isLoading || scripture.length;
-  const tabRoutes = [{ title: 'Devotional', key: 'devotional' }];
-  if (hasScripture) tabRoutes.push({ title: 'Scripture', key: 'scripture' });
+    isLoading,
+  }) => {
+    const hasScripture = isLoading || scripture.length;
+    const tabRoutes = [{ title: 'Devotional', key: 'devotional' }];
+    if (hasScripture) tabRoutes.push({ title: 'Scripture', key: 'scripture' });
 
-  const {
-    title: parentTitle,
-    content: { isLight = false } = {},
-    children = [],
-  } = parent || {};
+    const { title: parentTitle, content: { isLight = false } = {}, children = [] } = parent || {};
 
-  return (
-    <BackgroundView>
-      <Header titleText={parentTitle || 'Devotional'} backButton barStyle={isLight ? 'dark-content' : 'light-content'} />
-      <TabView
-        barStyle={isLight ? 'dark-content' : 'light-content'}
-        routes={tabRoutes}
-        renderScene={SceneMap({
-          devotional: withProps({
-            title,
-            body,
-            scripture,
-            otherContentProps,
-            entryData: children,
-            isLoading,
-          })(DevotionalTab),
-          scripture: withProps({
-            scripture,
-            entryData: children,
-            isLoading,
-          })(ScriptureTab),
-        })}
-      />
-      <SecondaryNav>
-        <ShareLink id={id} />
-        <Like id={id} isLiked={isLiked} />
-      </SecondaryNav>
-    </BackgroundView>
-  );
-});
+    return (
+      <BackgroundView>
+        <Header
+          titleText={parentTitle || 'Devotional'}
+          backButton
+          barStyle={isLight ? 'dark-content' : 'light-content'}
+        />
+        <TabView
+          barStyle={isLight ? 'dark-content' : 'light-content'}
+          routes={tabRoutes}
+          renderScene={SceneMap({
+            devotional: withProps({
+              title,
+              body,
+              scripture,
+              otherContentProps,
+              entryData: children,
+              isLoading,
+            })(DevotionalTab),
+            scripture: withProps({
+              scripture,
+              entryData: children,
+              isLoading,
+            })(ScriptureTab),
+          })}
+        />
+        <SecondaryNav isLoading={isLoading}>
+          <ShareLink id={id} />
+          <Like id={id} isLiked={isLiked} />
+        </SecondaryNav>
+      </BackgroundView>
+    );
+  },
+);
 
 export default Study;

--- a/src/studies/Single.js
+++ b/src/studies/Single.js
@@ -37,46 +37,39 @@ const enhance = compose(
 
 const ShareLink = withStudy(Share);
 
-const Study = enhance(({
-  id,
-  content: {
-    title,
+const Study = enhance(
+  ({
+    id,
     content: {
-      isLiked,
-      isLight = true,
-      description,
-      tags,
-      colors,
-      ...otherContentProps
+      title,
+      content: {
+        isLiked, isLight = true, description, tags, colors, ...otherContentProps
+      } = {},
+      children,
     } = {},
-    children,
-  } = { },
-  isLoading,
-}) => (
-  <BackgroundView>
-    <Header
-      titleText={title}
-      backButton
-      barStyle={isLight ? 'dark-content' : 'light-content'}
-    />
-    <ScrollView>
-      <ContentView
-        isLoading={isLoading}
-        imageOverlayColor={(!isLoading && colors && colors.length) ? `#${colors[0].value}` : ''}
-        {...otherContentProps}
-      >
-        <Title>{startCase(toLower(title))}</Title>
-        <HTMLView>{description}</HTMLView>
-      </ContentView>
-      <HorizontalTileFeed content={children} isLoading={isLoading} />
-      { // Don't render till data is ready. Consider adding placeholder views for the content above.
+    isLoading,
+  }) => (
+    <BackgroundView>
+      <Header titleText={title} backButton barStyle={isLight ? 'dark-content' : 'light-content'} />
+      <ScrollView>
+        <ContentView
+          isLoading={isLoading}
+          imageOverlayColor={!isLoading && colors && colors.length ? `#${colors[0].value}` : ''}
+          {...otherContentProps}
+        >
+          <Title>{startCase(toLower(title))}</Title>
+          <HTMLView>{description}</HTMLView>
+        </ContentView>
+        <HorizontalTileFeed content={children} isLoading={isLoading} />
+        {// Don't render till data is ready. Consider adding placeholder views for the content above.
         !isLoading && <RelatedContent tags={tags} excludedIds={[id]} />}
-    </ScrollView>
-    <SecondaryNav>
-      <ShareLink id={id} />
-      <Like id={id} isLiked={isLiked} />
-    </SecondaryNav>
-  </BackgroundView>
-));
+      </ScrollView>
+      <SecondaryNav isLoading={isLoading}>
+        <ShareLink id={id} />
+        <Like id={id} isLiked={isLiked} />
+      </SecondaryNav>
+    </BackgroundView>
+  ),
+);
 
 export default Study;

--- a/src/studies/Single.js
+++ b/src/studies/Single.js
@@ -61,7 +61,8 @@ const Study = enhance(
           <HTMLView>{description}</HTMLView>
         </ContentView>
         <HorizontalTileFeed content={children} isLoading={isLoading} />
-        {// Don't render till data is ready. Consider adding placeholder views for the content above.
+        {// Don't render till data is ready.
+        // Consider adding placeholder views for the content above.
         !isLoading && <RelatedContent tags={tags} excludedIds={[id]} />}
       </ScrollView>
       <SecondaryNav isLoading={isLoading}>


### PR DESCRIPTION
Fixes #549 

This attempts to load the secondary nav (think "like and share" nav) only AFTER the content loads. This should fix errors where there is no content to share.

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

