### PR TITLE
Created ternary for web view of settings menu

### DIFF
--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScrollView, Linking } from 'react-native';
+import { ScrollView, Linking, Platform } from 'react-native';
 import { withProps, compose } from 'recompose';
 import SafeAreaView from '@ui/SafeAreaView';
 import PaddedView from '@ui/PaddedView';
@@ -117,13 +117,15 @@ const Settings = () => (
           </TableView>
 
           <TableView>
-            <ShowOnboardingTouchable>
-              <Cell>
-                <CellText>Show Onboarding</CellText>
-                <Arrow />
-              </Cell>
-            </ShowOnboardingTouchable>
-            <Divider />
+            {Platform.OS !== 'web' ? (
+              <ShowOnboardingTouchable>
+                <Cell>
+                  <CellText>Show Onboarding</CellText>
+                  <Arrow />
+                </Cell>
+                <Divider />
+              </ShowOnboardingTouchable>
+            ) : null}
             <LogoutTouchable>
               <Cell>
                 <CellText>Logout</CellText>


### PR DESCRIPTION
Fixes #479 

This removes the "Show Onboarding" option from the Setting Menu when viewed on Web.

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

