### PR TITLE
Normalize Address State field across forms

### DIFF
--- a/src/@data/withCheckout/checkoutQuery.js
+++ b/src/@data/withCheckout/checkoutQuery.js
@@ -17,9 +17,9 @@ export default gql`
       lastName
       email
       campus { name, id: entityId }
-      home { street1, street2, city, state, zip, country }
+      home { id, street1, street2, city, state, zip, country }
     }
-    savedPaymentMethods: savedPayments(cache: false){
+    savedPaymentMethods: savedPayments(cache: false) {
       id: entityId
       name
       payment {

--- a/src/@data/withGive/setBillingAddress.js
+++ b/src/@data/withGive/setBillingAddress.js
@@ -2,23 +2,37 @@ import gql from 'graphql-tag';
 import { graphql } from 'react-apollo';
 
 export const MUTATION = gql`
-  mutation setBillingAddress($street1: String!, $street2: String, $countryId: String!, $city: String!, $stateId: String!, $zipCode: String!) {
-    setBillingAddress(street1: $street1, street2: $street2, countryId: $countryId, city: $city, stateId: $stateId, zipCode: $zipCode) @client
+  mutation setBillingAddress(
+    $street1: String!
+    $street2: String
+    $countryId: String!
+    $city: String!
+    $stateId: String!
+    $zipCode: String!
+  ) {
+    setBillingAddress(
+      street1: $street1
+      street2: $street2
+      countryId: $countryId
+      city: $city
+      stateId: $stateId
+      zipCode: $zipCode
+    ) @client
   }
 `;
 
 export default graphql(MUTATION, {
   props: ({ mutate }) => ({
-    setBillingAddress: props => (mutate({
-      variables: {
-        street1: props.street1,
-        street2: props.street2,
-        countryId: props.countryId,
-        city: props.city,
-        stateId: props.stateId,
-        zipCode: props.zipCode,
-      },
-    })),
+    setBillingAddress: props =>
+      mutate({
+        variables: {
+          street1: props.street1,
+          street2: props.street2,
+          countryId: props.countryId,
+          city: props.city,
+          stateId: props.stateId,
+          zipCode: props.zipCode,
+        },
+      }),
   }),
 });
-

--- a/src/@data/withUser/index.js
+++ b/src/@data/withUser/index.js
@@ -1,4 +1,5 @@
 import { compose } from 'recompose';
+import withAddressState from './withAddressState';
 import withLogin from './withLogin';
 import withLogout from './withLogout';
 import withRegister from './withRegister';
@@ -12,6 +13,7 @@ import withUpdateProfile from './withUpdateProfile';
 import withAttachPhotoIdToUser from './withAttachPhotoIdToUser';
 
 export default compose(
+  withAddressState,
   withLogin,
   withLogout,
   withRegister,

--- a/src/@data/withUser/withAddressState.js
+++ b/src/@data/withUser/withAddressState.js
@@ -1,0 +1,56 @@
+import gql from 'graphql-tag';
+import { graphql } from 'react-apollo';
+
+export const QUERY = gql`
+  query GetAddressState($state: Int!, $country: Int!) {
+    states: definedValues(id: $state, all: true) {
+      description
+      id
+      _id
+      value
+    }
+    countries: definedValues(id: $country, all: true) {
+      description
+      id
+      _id
+      value
+    }
+    person: currentPerson {
+      id
+      firstName
+      nickName
+      lastName
+      email
+      home {
+        id
+        street1
+        street2
+        city
+        state
+        zip
+        country
+      }
+    }
+  }
+`;
+
+export default graphql(QUERY, {
+  options: {
+    variables: {
+      state: 28,
+      country: 45,
+    },
+  },
+  props({ ownProps, data }) {
+    const {
+      countries, states, person, loading,
+    } = data;
+
+    return {
+      isLoading: ownProps.isLoading || loading,
+      countries: (countries || []).map(c => ({ label: c.description, id: c.value })),
+      states: (states || []).map(s => ({ label: s.description, id: s.value })),
+      person,
+    };
+  },
+});

--- a/src/@data/withUser/withUpdateHomeAddress.js
+++ b/src/@data/withUser/withUpdateHomeAddress.js
@@ -27,6 +27,18 @@ export default graphql(MUTATION, {
     updateHomeAddress: (params = {}) =>
       mutate({
         variables: pick(params, ['street1', 'street2', 'city', 'stateId', 'zip']),
+        optimisticResponse: {
+          __typename: 'Mutation',
+          updateHomeAddress: {
+            id: params.id,
+            __typename: 'Location',
+            street1: params.street1,
+            street2: params.street2,
+            city: params.city,
+            stateId: params.stateId,
+            zip: params.zip,
+          },
+        },
       }),
   }),
 });

--- a/src/@data/withUser/withUpdateHomeAddress.js
+++ b/src/@data/withUser/withUpdateHomeAddress.js
@@ -6,7 +6,6 @@ export const MUTATION = gql`
   mutation updateHomeAddress(
     $street1: String
     $street2: String
-    $countryId: String
     $city: String
     $stateId: String
     $zip: String
@@ -15,9 +14,8 @@ export const MUTATION = gql`
       input: {
         Street1: $street1
         Street2: $street2
-        CountryId: $countryId
         City: $city
-        StateId: $stateId
+        State: $stateId
         PostalCode: $zip
       }
     )
@@ -28,7 +26,7 @@ export default graphql(MUTATION, {
   props: ({ mutate }) => ({
     updateHomeAddress: (params = {}) =>
       mutate({
-        variables: pick(params, ['street1', 'street2', 'countryId', 'city', 'stateId', 'zip']),
+        variables: pick(params, ['street1', 'street2', 'city', 'stateId', 'zip']),
       }),
   }),
 });

--- a/src/@data/withUser/withUpdateHomeAddress.js
+++ b/src/@data/withUser/withUpdateHomeAddress.js
@@ -4,32 +4,31 @@ import pick from 'lodash/pick';
 
 export const MUTATION = gql`
   mutation updateHomeAddress(
-    $street1: String,
-    $street2: String,
-    $city: String,
-    $state: String,
+    $street1: String
+    $street2: String
+    $countryId: String
+    $city: String
+    $stateId: String
     $zip: String
   ) {
-    updateHomeAddress(input: {
-      Street1: $street1
-      Street2: $street2
-      City: $city
-      State: $state
-      PostalCode: $zip
-    })
+    updateHomeAddress(
+      input: {
+        Street1: $street1
+        Street2: $street2
+        CountryId: $countryId
+        City: $city
+        StateId: $stateId
+        PostalCode: $zip
+      }
+    )
   }
 `;
 
 export default graphql(MUTATION, {
   props: ({ mutate }) => ({
-    updateHomeAddress: (params = {}) => (mutate({
-      variables: pick(params, [
-        'street1',
-        'street2',
-        'city',
-        'state',
-        'zip',
-      ]),
-    })),
+    updateHomeAddress: (params = {}) =>
+      mutate({
+        variables: pick(params, ['street1', 'street2', 'countryId', 'city', 'stateId', 'zip']),
+      }),
   }),
 });

--- a/src/@ui/forms/BillingAddressForm.js
+++ b/src/@ui/forms/BillingAddressForm.js
@@ -8,6 +8,7 @@ import Yup from 'yup';
 
 import withGive from '@data/withGive';
 import withCheckout from '@data/withCheckout';
+import withUser from '@data/withUser';
 import { withRouter } from '@ui/NativeWebRouter';
 import PaddedView from '@ui/PaddedView';
 import TableView, { FormFields } from '@ui/TableView';
@@ -158,17 +159,18 @@ const validationSchema = Yup.object().shape({
 });
 
 const mapPropsToValues = props => ({
-  street1: get(props, 'contributions.street1') || get(props, 'person.home.street1', ''),
-  street2: get(props, 'contributions.street2') || get(props, 'person.home.street2', ''),
-  city: get(props, 'contributions.city') || get(props, 'person.home.city', ''),
-  stateId: get(props, 'contributions.stateId') || get(props, 'person.home.state') || 'SC',
-  countryId: get(props, 'contributions.countryId') || get(props, 'person.home.country') || 'US',
-  zipCode: get(props, 'contributions.zipCode') || get(props, 'person.home.zip', ''),
+  street1: get(props, 'contributions.street1') || get(props, 'user.home.street1', ''),
+  street2: get(props, 'contributions.street2') || get(props, 'user.home.street2', ''),
+  city: get(props, 'contributions.city') || get(props, 'user.home.city', ''),
+  stateId: get(props, 'contributions.stateId') || get(props, 'user.home.state') || 'SC',
+  countryId: get(props, 'contributions.countryId') || get(props, 'user.home.country') || 'US',
+  zipCode: get(props, 'contributions.zipCode') || get(props, 'user.home.zip', ''),
 });
 
 const BillingAddressForm = compose(
   withGive,
   withCheckout,
+  withUser,
   withRouter,
   withFormik({
     mapPropsToValues,

--- a/src/@ui/forms/BillingAddressForm.js
+++ b/src/@ui/forms/BillingAddressForm.js
@@ -8,7 +8,6 @@ import Yup from 'yup';
 
 import withGive from '@data/withGive';
 import withCheckout from '@data/withCheckout';
-import withUser from '@data/withUser';
 import { withRouter } from '@ui/NativeWebRouter';
 import PaddedView from '@ui/PaddedView';
 import TableView, { FormFields } from '@ui/TableView';
@@ -159,18 +158,17 @@ const validationSchema = Yup.object().shape({
 });
 
 const mapPropsToValues = props => ({
-  street1: get(props, 'user.home.street1', ''),
-  street2: get(props, 'user.home.street2', ''),
-  city: get(props, 'user.home.city', ''),
-  stateId: get(props, 'user.home.state') || 'SC',
-  countryId: get(props, 'user.home.country') || 'US',
-  zipCode: get(props, 'user.home.zip', ''),
+  street1: get(props, 'contributions.street1') || get(props, 'person.home.street1', ''),
+  street2: get(props, 'contributions.street2') || get(props, 'person.home.street2', ''),
+  city: get(props, 'contributions.city') || get(props, 'person.home.city', ''),
+  stateId: get(props, 'contributions.stateId') || get(props, 'person.home.stateId') || 'SC',
+  countryId: get(props, 'contributions.countryId') || get(props, 'person.home.countryId') || 'US',
+  zipCode: get(props, 'contributions.zipCode') || get(props, 'person.home.zip', ''),
 });
 
 const BillingAddressForm = compose(
   withGive,
   withCheckout,
-  withUser,
   withRouter,
   withFormik({
     mapPropsToValues,

--- a/src/@ui/forms/BillingAddressForm.js
+++ b/src/@ui/forms/BillingAddressForm.js
@@ -159,12 +159,12 @@ const validationSchema = Yup.object().shape({
 });
 
 const mapPropsToValues = props => ({
-  street1: get(props, 'contributions.street1') || get(props, 'user.home.street1', ''),
-  street2: get(props, 'contributions.street2') || get(props, 'user.home.street2', ''),
-  city: get(props, 'contributions.city') || get(props, 'user.home.city', ''),
-  stateId: get(props, 'contributions.stateId') || get(props, 'user.home.state') || 'SC',
-  countryId: get(props, 'contributions.countryId') || get(props, 'user.home.country') || 'US',
-  zipCode: get(props, 'contributions.zipCode') || get(props, 'user.home.zip', ''),
+  street1: get(props, 'user.home.street1', ''),
+  street2: get(props, 'user.home.street2', ''),
+  city: get(props, 'user.home.city', ''),
+  stateId: get(props, 'user.home.state') || 'SC',
+  countryId: get(props, 'user.home.country') || 'US',
+  zipCode: get(props, 'user.home.zip', ''),
 });
 
 const BillingAddressForm = compose(

--- a/src/@ui/forms/ProfileAddressForm.js
+++ b/src/@ui/forms/ProfileAddressForm.js
@@ -178,6 +178,7 @@ const ProfileAddressForm = compose(
       setSubmitting(true);
       try {
         await props.updateHomeAddress({
+          id: props.person.home.id,
           street1: values.street1,
           street2: values.street2,
           countryId: values.countryId,

--- a/src/@ui/forms/ProfileAddressForm.js
+++ b/src/@ui/forms/ProfileAddressForm.js
@@ -78,7 +78,6 @@ export const ProfileAddressFormWithoutData = enhance(
     status,
   }) => {
     const isUSOrCanada = values.countryId === 'US' || values.countryId === 'CA';
-
     return (
       <PaddedView horizontal={false}>
         <TableView>
@@ -159,12 +158,12 @@ const validationSchema = Yup.object().shape({
 });
 
 const mapPropsToValues = props => ({
-  street1: get(props, 'user.street1') || get(props, 'person.home.street1', ''),
-  street2: get(props, 'user.street2') || get(props, 'person.home.street2', ''),
-  city: get(props, 'user.city') || get(props, 'person.home.city', ''),
-  stateId: get(props, 'user.stateId') || get(props, 'person.home.state') || 'SC',
-  countryId: get(props, 'user.countryId') || get(props, 'person.home.country') || 'US',
-  zipCode: get(props, 'user.zipCode') || get(props, 'person.home.zip', ''),
+  street1: get(props, 'person.home.street1', ''),
+  street2: get(props, 'person.home.street2', ''),
+  city: get(props, 'person.home.city', ''),
+  stateId: get(props, 'person.home.state') || 'SC',
+  countryId: get(props, 'person.home.country') || 'US',
+  zip: get(props, 'person.home.zip', ''),
 });
 
 const ProfileAddressForm = compose(

--- a/src/@ui/forms/ProfileAddressForm.js
+++ b/src/@ui/forms/ProfileAddressForm.js
@@ -9,7 +9,6 @@ import * as Inputs from '@ui/inputs';
 import TableView from '@ui/TableView';
 import PaddedView from '@ui/PaddedView';
 import withUser from '@data/withUser';
-import withCheckout from '@data/withCheckout';
 import Button from '@ui/Button';
 import { H6 } from '@ui/typography';
 import styled from '@ui/styled';
@@ -158,18 +157,17 @@ const validationSchema = Yup.object().shape({
 });
 
 const mapPropsToValues = props => ({
-  street1: get(props, 'person.home.street1', ''),
-  street2: get(props, 'person.home.street2', ''),
-  city: get(props, 'person.home.city', ''),
-  stateId: get(props, 'person.home.state') || 'SC',
-  countryId: get(props, 'person.home.country') || 'US',
-  zip: get(props, 'person.home.zip', ''),
+  street1: get(props, 'user.home.street1', ''),
+  street2: get(props, 'user.home.street2', ''),
+  city: get(props, 'user.home.city', ''),
+  stateId: get(props, 'user.home.state') || 'SC',
+  countryId: get(props, 'user.home.country') || 'US',
+  zip: get(props, 'user.home.zip', ''),
 });
 
 const ProfileAddressForm = compose(
   pure,
   withUser,
-  withCheckout,
   branch(({ isLoading }) => isLoading, renderComponent(ActivityIndicator)),
   withFormik({
     mapPropsToValues,

--- a/src/@ui/forms/ProfileAddressForm.js
+++ b/src/@ui/forms/ProfileAddressForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { compose, branch, renderComponent, pure } from 'recompose';
+import { compose, branch, renderComponent, setPropTypes, pure } from 'recompose';
 import Yup from 'yup';
 import { withFormik } from 'formik';
 import get from 'lodash/get';
@@ -9,113 +9,168 @@ import * as Inputs from '@ui/inputs';
 import TableView from '@ui/TableView';
 import PaddedView from '@ui/PaddedView';
 import withUser from '@data/withUser';
+import withCheckout from '@data/withCheckout';
 import Button from '@ui/Button';
 import { H6 } from '@ui/typography';
 import styled from '@ui/styled';
 
 const Status = styled({ textAlign: 'center' })(H6);
 
-export const ProfileAddressFormWithoutData = ({
-  setFieldValue,
-  handleSubmit,
-  values,
-  setFieldTouched,
-  errors,
-  touched,
-  isSubmitting,
-  isValid,
-  status,
-}) => (
-  <PaddedView horizontal={false}>
-    <TableView>
-      <PaddedView>
-        <Inputs.Text
-          label="Street"
-          value={values.street1}
-          onChangeText={text => setFieldValue('street1', text)}
-          onBlur={() => setFieldTouched('street1', true)}
-          error={touched.street1 && errors.street1}
-        />
-        <Inputs.Text
-          label="Street 2 (Optional)"
-          value={values.street2}
-          onChangeText={text => setFieldValue('street2', text)}
-          onBlur={() => setFieldTouched('street2', true)}
-          error={touched.street2 && errors.street2}
-        />
-        <Inputs.Text
-          label="City"
-          value={values.city}
-          onChangeText={text => setFieldValue('city', text)}
-          onBlur={() => setFieldTouched('city', true)}
-          error={touched.city && errors.city}
-        />
-        <Inputs.Text
-          label="State"
-          value={values.state}
-          onChangeText={text => setFieldValue('state', text)}
-          onBlur={() => setFieldTouched('state', true)}
-          error={touched.state && errors.state}
-        />
-        <Inputs.Text
-          label="Zip"
-          value={values.zip}
-          onChangeText={text => setFieldValue('zip', text)}
-          onBlur={() => setFieldTouched('zip', true)}
-          error={touched.zip && errors.zip}
-        />
-      </PaddedView>
-    </TableView>
-    {status ? <Status>{status}</Status> : null}
-    <PaddedView>
-      <Button onPress={handleSubmit} title="Save" disabled={!isValid} loading={isSubmitting} />
-    </PaddedView>
-  </PaddedView>
+const enhance = compose(
+  setPropTypes({
+    setFieldValue: PropTypes.func,
+    handleSubmit: PropTypes.func,
+    countries: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        label: PropTypes.string,
+      }),
+    ),
+    states: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        label: PropTypes.string,
+      }),
+    ),
+    values: PropTypes.shape({
+      street1: PropTypes.string,
+      street2: PropTypes.string,
+      countryId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      city: PropTypes.string,
+      stateId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      zip: PropTypes.string,
+    }),
+    setFieldTouched: PropTypes.func,
+    errors: PropTypes.shape({
+      street1: PropTypes.string,
+      street2: PropTypes.string,
+      countryId: PropTypes.string,
+      city: PropTypes.string,
+      stateId: PropTypes.string,
+      zip: PropTypes.string,
+    }),
+    touched: PropTypes.shape({
+      street1: PropTypes.bool,
+      street2: PropTypes.bool,
+      countryId: PropTypes.bool,
+      city: PropTypes.bool,
+      stateId: PropTypes.bool,
+      zip: PropTypes.bool,
+    }),
+    isSubmitting: PropTypes.bool,
+    isValid: PropTypes.bool,
+    status: PropTypes.string,
+  }),
 );
 
-ProfileAddressFormWithoutData.propTypes = {
-  setFieldValue: PropTypes.func,
-  handleSubmit: PropTypes.func,
-  values: PropTypes.shape({
-    street1: PropTypes.string,
-    street2: PropTypes.string,
-    city: PropTypes.string,
-    state: PropTypes.string,
-    zip: PropTypes.string,
-  }),
-  setFieldTouched: PropTypes.func,
-  errors: PropTypes.shape({
-    street1: PropTypes.string,
-    street2: PropTypes.string,
-    city: PropTypes.string,
-    state: PropTypes.string,
-    zip: PropTypes.string,
-  }),
-  touched: PropTypes.shape({
-    street1: PropTypes.bool,
-    street2: PropTypes.bool,
-    city: PropTypes.bool,
-    state: PropTypes.bool,
-    zip: PropTypes.bool,
-  }),
-  isSubmitting: PropTypes.bool,
-  isValid: PropTypes.bool,
-  status: PropTypes.string,
-};
+export const ProfileAddressFormWithoutData = enhance(
+  ({
+    setFieldValue,
+    handleSubmit,
+    values,
+    countries,
+    states,
+    setFieldTouched,
+    errors,
+    touched,
+    isSubmitting,
+    isValid,
+    status,
+  }) => {
+    const isUSOrCanada = values.countryId === 'US' || values.countryId === 'CA';
+
+    return (
+      <PaddedView horizontal={false}>
+        <TableView>
+          <PaddedView>
+            <Inputs.Text
+              label="Street"
+              value={values.street1}
+              onChangeText={text => setFieldValue('street1', text)}
+              onBlur={() => setFieldTouched('street1', true)}
+              error={touched.street1 && errors.street1}
+            />
+            <Inputs.Text
+              label="Street 2 (Optional)"
+              value={values.street2}
+              onChangeText={text => setFieldValue('street2', text)}
+              onBlur={() => setFieldTouched('street2', true)}
+              error={touched.street2 && errors.street2}
+            />
+            <Inputs.Picker
+              label="Country"
+              value={values.countryId}
+              displayValue={get(
+                countries.find(country => country.id === values.countryId),
+                'label',
+              )}
+              onValueChange={value => setFieldValue('countryId', value)}
+              error={touched.countryId && errors.countryId}
+            >
+              {countries.map(({ label, id }) => (
+                <Inputs.PickerItem label={label} value={id} key={id} />
+              ))}
+            </Inputs.Picker>
+            <Inputs.Text
+              label="City"
+              value={values.city}
+              onChangeText={text => setFieldValue('city', text)}
+              onBlur={() => setFieldTouched('city', true)}
+              error={touched.city && errors.city}
+            />
+            {isUSOrCanada && (
+              <Inputs.Picker
+                label="State/Territory"
+                value={values.stateId}
+                displayValue={get(states.find(state => state.id === values.stateId), 'label')}
+                onValueChange={value => setFieldValue('stateId', value)}
+                error={touched.stateId && errors.stateId}
+              >
+                {states.map(({ label, id }) => (
+                  <Inputs.PickerItem label={label} value={id} key={id} />
+                ))}
+              </Inputs.Picker>
+            )}
+            <Inputs.Text
+              label="Zip"
+              value={values.zip}
+              onChangeText={text => setFieldValue('zip', text)}
+              onBlur={() => setFieldTouched('zip', true)}
+              error={touched.zip && errors.zip}
+            />
+          </PaddedView>
+        </TableView>
+        {status ? <Status>{status}</Status> : null}
+        <PaddedView>
+          <Button onPress={handleSubmit} title="Save" disabled={!isValid} loading={isSubmitting} />
+        </PaddedView>
+      </PaddedView>
+    );
+  },
+);
 
 const validationSchema = Yup.object().shape({
-  street: Yup.string(),
+  street1: Yup.string(),
   street2: Yup.string().nullable(),
   city: Yup.string(),
-  state: Yup.string(),
+  stateId: Yup.string(),
+  countryId: Yup.string(),
   zip: Yup.string(),
 });
 
-const mapPropsToValues = props => get(props, 'user.home', {});
+const mapPropsToValues = props => ({
+  street1: get(props, 'user.street1') || get(props, 'person.home.street1', ''),
+  street2: get(props, 'user.street2') || get(props, 'person.home.street2', ''),
+  city: get(props, 'user.city') || get(props, 'person.home.city', ''),
+  stateId: get(props, 'user.stateId') || get(props, 'person.home.state') || 'SC',
+  countryId: get(props, 'user.countryId') || get(props, 'person.home.country') || 'US',
+  zipCode: get(props, 'user.zipCode') || get(props, 'person.home.zip', ''),
+});
 
 const ProfileAddressForm = compose(
   pure,
   withUser,
+  withCheckout,
   branch(({ isLoading }) => isLoading, renderComponent(ActivityIndicator)),
   withFormik({
     mapPropsToValues,
@@ -126,8 +181,9 @@ const ProfileAddressForm = compose(
         await props.updateHomeAddress({
           street1: values.street1,
           street2: values.street2,
+          countryId: values.countryId,
           city: values.city,
-          state: values.state,
+          stateId: values.stateId,
           zip: values.zip,
         });
         setStatus('Your address was updated.');


### PR DESCRIPTION
Fixes #440 

## Creator

- [x] Build relevant tests if any apply
- [x] Ensure there are no new warnings
- [x] Upload an animated GIF showcasing the solution (if it applies)
- [x] Set a relevant reviewer

## Reviewer

- [x] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

I added an input picker for state in the Profile AddressForm. With this change, I created a new data component, withAddressState, within withUser that can be used in BillingAddressForm so that changes made to Profile Address can be used elsewhere and not have to have withCheckout in the ProfileAddressForm.
