### PR TITLE
547 fix music player theming 

### DIFF
--- a/src/music/Player/FullScreenControls/index.js
+++ b/src/music/Player/FullScreenControls/index.js
@@ -54,7 +54,7 @@ const IconWithActiveOpacity = styled(({ theme, active }) => ({
 }))(Icon);
 
 const enhance = compose(
-  withThemeMixin({ type: 'dark' }),
+  withThemeMixin(({ isLight }) => ({ type: isLight ? 'light' : 'dark' })),
   setPropTypes({
     isPlaying: PropTypes.bool,
     duration: PropTypes.string,
@@ -66,6 +66,7 @@ const enhance = compose(
     trackByLine: PropTypes.string,
     albumArt: PropTypes.any, // eslint-disable-line
     color: PropTypes.string,
+    isLight: PropTypes.bool,
     isShuffling: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
     isRepeating: PropTypes.bool,
     handleShuffle: PropTypes.func,

--- a/src/music/Player/index.js
+++ b/src/music/Player/index.js
@@ -86,6 +86,7 @@ export class DockableMediaPlayer extends PureComponent {
     title: PropTypes.string,
     images: PropTypes.any, // eslint-disable-line
     colors: PropTypes.arrayOf(PropTypes.shape({ value: PropTypes.string })), // eslint-disable-line
+    isLight: PropTypes.bool,
     children: PropTypes.node,
     playNextTrack: PropTypes.func,
     playPrevTrack: PropTypes.func,
@@ -153,7 +154,7 @@ export class DockableMediaPlayer extends PureComponent {
 
   handlePlayerError = () => {
     this.props.pause(); // todo: show some UI indication, this is likely a network error
-  }
+  };
 
   renderMiniControls() {
     let miniControls = null;
@@ -190,6 +191,7 @@ export class DockableMediaPlayer extends PureComponent {
       trackByLine={`${this.props.artist} - ${this.props.title}`}
       albumArt={this.props.images}
       color={this.primaryColor}
+      isLight={this.props.isLight}
       handleClose={this.contract}
       duration={this.props.currentTrack.duration}
       isRepeating={this.props.isRepeating}


### PR DESCRIPTION
Fixes #547 by making it respect theming instead of forcing the dark theme all the time. Passed down `isLight` from where the album query was happening so that theme switching would be dynamic.

### iOS
![simulator screen shot - iphone x - 2018-05-03 at 17 23 13](https://user-images.githubusercontent.com/2053547/39604065-b3fa109c-4ef8-11e8-8c71-487199a79269.png)
![simulator screen shot - iphone x - 2018-05-03 at 17 23 27](https://user-images.githubusercontent.com/2053547/39604068-b6235c48-4ef8-11e8-87f6-cf238757d44f.png)
### Android
![screenshot_1525383061](https://user-images.githubusercontent.com/2053547/39604074-bab84d90-4ef8-11e8-8ec7-ca7e25e4969a.png)
![screenshot_1525383080](https://user-images.githubusercontent.com/2053547/39604076-bc592340-4ef8-11e8-859a-c8df82cedb97.png)

## Creator

- [x] Build relevant tests if any apply
- [x] Ensure there are no new warnings
- [x] Upload an animated GIF showcasing the solution (if it applies)
- [x] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

