### PR TITLE
Tablet Secondary Nav

### DIFF
--- a/src/@ui/SecondaryNav/index.js
+++ b/src/@ui/SecondaryNav/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { withProps, compose } from 'recompose';
 import withToggleLike from '@data/likes/withToggleLike';
@@ -20,6 +21,18 @@ export const Like = compose(
   })),
 )(Link);
 
+const styles = StyleSheet.create({
+  tabBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+  },
+  fullWidthTabBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    width: '100%',
+  },
+});
+
 const SecondaryNav = ({
   backButton = false,
   backButtonIcon = 'arrow-back',
@@ -28,9 +41,10 @@ const SecondaryNav = ({
   children,
   onBackReplace,
   isLoading = false,
+  fullWidth = false,
 }) =>
   (!isLoading ? (
-    <TabBar>
+    <TabBar style={fullWidth ? styles.fullWidthTabBar : styles.tabBar}>
       {backButton ? (
         <Link pop to={backTo} icon={backButtonIcon} onPress={onBackPress} replace={onBackReplace} />
       ) : null}
@@ -46,6 +60,7 @@ SecondaryNav.propTypes = {
   backTo: PropTypes.string,
   onBackReplace: PropTypes.bool,
   isLoading: PropTypes.bool,
+  fullWidth: PropTypes.bool,
 };
 
 export default SecondaryNav;

--- a/src/articles/Single.js
+++ b/src/articles/Single.js
@@ -7,7 +7,6 @@ import withCachedContent from '@data/withCachedContent';
 import BackgroundView from '@ui/BackgroundView';
 import Header from '@ui/Header';
 import ContentView, { Title, ByLine, HTMLView } from '@ui/ContentView';
-import MediaQuery from '@ui/MediaQuery';
 import RelatedContent from '@ui/RelatedContent';
 import SecondaryNav, { Like, Share } from '@ui/SecondaryNav';
 
@@ -44,12 +43,10 @@ const ArticleSingle = enhance(
         // Consider adding placeholder views for the content above.
         !isLoading && <RelatedContent tags={tags} excludedIds={[id]} />}
       </ScrollView>
-      <MediaQuery maxWidth="md">
-        <SecondaryNav isLoading={isLoading}>
-          <ShareLink id={id} />
-          <Like id={id} isLiked={isLiked} />
-        </SecondaryNav>
-      </MediaQuery>
+      <SecondaryNav isLoading={isLoading} fullWidth>
+        <ShareLink id={id} />
+        <Like id={id} isLiked={isLiked} />
+      </SecondaryNav>
     </BackgroundView>
   ),
 );

--- a/src/group-finder/GroupSingle.js
+++ b/src/group-finder/GroupSingle.js
@@ -268,12 +268,10 @@ const GroupSingle = enhance(
             </MediaQuery>
           ) : null}
         </FlexedSideBySideView>
-        <MediaQuery maxWidth="md">
-          <SecondaryNav isLoading={isLoading}>
-            <ShareLink id={id} />
-            <Like id={id} isLiked={isLiked} />
-          </SecondaryNav>
-        </MediaQuery>
+        <SecondaryNav isLoading={isLoading} fullWidth>
+          <ShareLink id={id} />
+          <Like id={id} isLiked={isLiked} />
+        </SecondaryNav>
       </BackgroundView>
     );
   },

--- a/src/music/Playlist.js
+++ b/src/music/Playlist.js
@@ -4,7 +4,6 @@ import BackgroundView from '@ui/BackgroundView';
 import Header from '@ui/Header';
 import TracksList from '@ui/TracksList';
 import AlbumView from '@ui/AlbumView';
-import MediaQuery from '@ui/MediaQuery';
 import SecondaryNav, { Like, Share } from '@ui/SecondaryNav';
 import { withPlaylist, withMediaPlayerActions, withNowPlaying } from '@data/mediaPlayer';
 import { getBlurredImageSource, getAlbumImageSource } from '@utils/content';
@@ -51,12 +50,10 @@ const Playlist = enhance(
           />
         }
       />
-      <MediaQuery maxWidth="md">
-        <SecondaryNav isLoading={isLoading}>
-          <ShareLink id={id} />
-          <Like id={id} isLiked={isLiked} />
-        </SecondaryNav>
-      </MediaQuery>
+      <SecondaryNav isLoading={isLoading} fullWidth>
+        <ShareLink id={id} />
+        <Like id={id} isLiked={isLiked} />
+      </SecondaryNav>
     </BackgroundView>
   ),
 );

--- a/src/news/Single.js
+++ b/src/news/Single.js
@@ -6,7 +6,6 @@ import { startCase, toLower } from 'lodash';
 import BackgroundView from '@ui/BackgroundView';
 import Header from '@ui/Header';
 import ContentView, { Title, ByLine, HTMLView } from '@ui/ContentView';
-import MediaQuery from '@ui/MediaQuery';
 import SecondaryNav, { Like, Share } from '@ui/SecondaryNav';
 import withNewsStory from '@data/withNewsStory';
 import withCachedContent from '@data/withCachedContent';
@@ -39,12 +38,10 @@ const NewsSingle = enhance(
           <HTMLView>{body}</HTMLView>
         </ContentView>
       </ScrollView>
-      <MediaQuery maxWidth="md">
-        <SecondaryNav isLoading={isLoading}>
-          <ShareLink id={id} />
-          <Like id={id} isLiked={isLiked} />
-        </SecondaryNav>
-      </MediaQuery>
+      <SecondaryNav isLoading={isLoading} fullWidth>
+        <ShareLink id={id} />
+        <Like id={id} isLiked={isLiked} />
+      </SecondaryNav>
     </BackgroundView>
   ),
 );

--- a/src/series/Sermon.js
+++ b/src/series/Sermon.js
@@ -71,7 +71,7 @@ const Sermon = enhance(
         </ContentView>
         <HorizontalTileFeed content={children} isLoading={isLoading} showTileMeta />
       </ScrollView>
-      <SecondaryNav isLoading={isLoading}>
+      <SecondaryNav isLoading={isLoading} fullWidth>
         <ShareLink id={id} />
         <Like id={id} isLiked={isLiked} />
       </SecondaryNav>

--- a/src/series/Single.js
+++ b/src/series/Single.js
@@ -93,7 +93,7 @@ const SeriesSingle = enhance(
         // Consider adding placeholder views for the content above.
         !isLoading && <RelatedContent tags={tags} excludedIds={[id]} />}
       </ScrollView>
-      <SecondaryNav isLoading={isLoading}>
+      <SecondaryNav isLoading={isLoading} fullWidth>
         <ShareLink id={id} />
         <Like id={id} isLiked={isLiked} />
       </SecondaryNav>

--- a/src/stories/Single.js
+++ b/src/stories/Single.js
@@ -7,7 +7,6 @@ import withStory from '@data/withStory';
 import BackgroundView from '@ui/BackgroundView';
 import Header from '@ui/Header';
 import ContentView, { ByLine, Title, HTMLView } from '@ui/ContentView';
-import MediaQuery from '@ui/MediaQuery';
 import SecondaryNav, { Like, Share } from '@ui/SecondaryNav';
 import RelatedContent from '@ui/RelatedContent';
 import withCachedContent from '@data/withCachedContent';
@@ -43,12 +42,10 @@ const StorySingle = enhance(
         </ContentView>
         <RelatedContent tags={tags} excludedIds={[id]} />
       </ScrollView>
-      <MediaQuery maxWidth="md">
-        <SecondaryNav isLoading={isLoading}>
-          <ShareLink id={id} />
-          <Like id={id} isLiked={isLiked} />
-        </SecondaryNav>
-      </MediaQuery>
+      <SecondaryNav isLoading={isLoading} fullWidth>
+        <ShareLink id={id} />
+        <Like id={id} isLiked={isLiked} />
+      </SecondaryNav>
     </BackgroundView>
   ),
 );

--- a/src/studies/Entry/index.js
+++ b/src/studies/Entry/index.js
@@ -85,7 +85,7 @@ const Study = enhance(
             })(ScriptureTab),
           })}
         />
-        <SecondaryNav isLoading={isLoading}>
+        <SecondaryNav isLoading={isLoading} fullWidth>
           <ShareLink id={id} />
           <Like id={id} isLiked={isLiked} />
         </SecondaryNav>

--- a/src/studies/Single.js
+++ b/src/studies/Single.js
@@ -65,7 +65,7 @@ const Study = enhance(
         // Consider adding placeholder views for the content above.
         !isLoading && <RelatedContent tags={tags} excludedIds={[id]} />}
       </ScrollView>
-      <SecondaryNav isLoading={isLoading}>
+      <SecondaryNav isLoading={isLoading} fullWidth>
         <ShareLink id={id} />
         <Like id={id} isLiked={isLiked} />
       </SecondaryNav>


### PR DESCRIPTION
Fixes #584. This makes sure that the secondary nav on tablets displays horizontally along the bottom on content items while not breaking the secondary nav (like the "X") that displays in places like the sections menu. 

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [x] Run `test` and make sure all tests pass
- [x] Review function and form on iOS
- [ ] Review function and form on Android
- [x] Review function and form on Web
- [x] Review new test logic

![screenshot 2018-05-09 09 45 20](https://user-images.githubusercontent.com/3229463/39818015-d8569090-536d-11e8-91e4-b856bbe86477.png)
![screenshot 2018-05-09 09 45 10](https://user-images.githubusercontent.com/3229463/39818016-d9e23dc4-536d-11e8-8aed-23cf463b91fe.png)

