### PR TITLE
Fix secondary menu on group finder

### DIFF
--- a/src/group-finder/GroupSingle.js
+++ b/src/group-finder/GroupSingle.js
@@ -268,10 +268,12 @@ const GroupSingle = enhance(
             </MediaQuery>
           ) : null}
         </FlexedSideBySideView>
-        <SecondaryNav isLoading={isLoading} fullWidth>
-          <ShareLink id={id} />
-          <Like id={id} isLiked={isLiked} />
-        </SecondaryNav>
+        {Platform.OS !== 'web' ? (
+          <SecondaryNav isLoading={isLoading} fullWidth>
+            <ShareLink id={id} />
+            <Like id={id} isLiked={isLiked} />
+          </SecondaryNav>
+        ) : null}
       </BackgroundView>
     );
   },


### PR DESCRIPTION
Remove the share menu on an individual group if it is being displayed on the web

Fixes #606 

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [x] Run `test` and make sure all tests pass
- [x] Review function and form on iOS
- [x] Review function and form on Android
- [x] Review function and form on Web
- [ ] Review new test logic

