### PR TITLE
perf optimizations

### DIFF
--- a/src/@data/withGivingDashboard/index.js
+++ b/src/@data/withGivingDashboard/index.js
@@ -1,15 +1,21 @@
 import { graphql } from 'react-apollo';
+import { compose, withPropsOnChange } from 'recompose';
 import givingDashboardQuery from './givingDashboardQuery';
 
-export default graphql(givingDashboardQuery, {
-  props: ({ data, ownProps }) => ({
-    isLoading: ownProps.isLoading || data.loading,
-    scheduledTransactions: data.scheduledTransactions || [],
-    activityItems: data.activityItems || [],
-    savedPaymentMethods: (data.savedPaymentMethods || []).map(pm => ({
+export default compose(
+  graphql(givingDashboardQuery, {
+    props: ({ data, ownProps }) => ({
+      isLoading: ownProps.isLoading || data.loading,
+      scheduledTransactions: data.scheduledTransactions || [],
+      activityItems: data.activityItems || [],
+      savedPaymentMethods: data.savedPaymentMethods || [],
+    }),
+  }),
+  withPropsOnChange(['savedPaymentMethods'], ({ savedPaymentMethods }) => ({
+    savedPaymentMethods: savedPaymentMethods.map(pm => ({
       ...pm,
       paymentMethod: pm.payment.paymentType === 'ACH' ? 'bankAccount' : 'creditCard',
       accountNumber: pm.payment.accountNumber,
     })),
-  }),
-});
+  })),
+);

--- a/src/@ui/styled/createStyleSheet.js
+++ b/src/@ui/styled/createStyleSheet.js
@@ -20,21 +20,23 @@ const createStyleSheet = (stylesToGenerate) => {
     }
   });
 
-  // Generate the new stylesheet
-  const generatedStyleSheet = StyleSheet.create(styleSheet);
+  if (Object.keys(styleSheet).length) {
+    // Generate the new stylesheet
+    const generatedStyleSheet = StyleSheet.create(styleSheet);
 
-  // Process the generated stylesheet
-  Object.keys(generatedStyleSheet).forEach((key) => {
-    const index = parseInt(key, 0);
-    const generatedStyle = generatedStyleSheet[key];
-    const hash = styleHasher(styles[index]);
+    // Process the generated stylesheet
+    Object.keys(generatedStyleSheet).forEach((key) => {
+      const index = parseInt(key, 0);
+      const generatedStyle = generatedStyleSheet[key];
+      const hash = styleHasher(styles[index]);
 
-    // add generated style to cache
-    cachedStyles[hash] = generatedStyle;
+      // add generated style to cache
+      cachedStyles[hash] = generatedStyle;
 
-    // swap generated style into result list
-    styles[index] = generatedStyle;
-  });
+      // swap generated style into result list
+      styles[index] = generatedStyle;
+    });
+  }
 
   if (styles.length === 1) styles = styles[0]; // eslint-disable-line
   return styles;

--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -200,6 +200,7 @@ class AppRouter extends PureComponent {
     // On Web we render the tab layout at this level as tabs are visible in all app routes
     // On mobile, use a CardStack component for animated transitions and swipe to go back.
     const AppLayout = Platform.OS === 'web' ? tabs.Layout : BackgroundView;
+    const NavigatorStack = Platform.OS === 'web' ? Switch : CardStack;
 
     return (
       <BackgroundView>
@@ -214,7 +215,7 @@ class AppRouter extends PureComponent {
         ) : (
           <Player>
             <AppLayout>
-              <CardStack
+              <NavigatorStack
                 location={
                   this.isModal || this.musicPlayerIsOpened ? previousLocation : this.props.location
                 }
@@ -308,7 +309,7 @@ class AppRouter extends PureComponent {
                 <Route exact path="/_/reset-password/:token" component={ResetPassword} />
 
                 <Route cardStackKey="tabs" component={this.tabs} />
-              </CardStack>
+              </NavigatorStack>
             </AppLayout>
             <Switch>{this.isModal ? this.largeScreenModals : null}</Switch>
           </Player>

--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -200,7 +200,6 @@ class AppRouter extends PureComponent {
     // On Web we render the tab layout at this level as tabs are visible in all app routes
     // On mobile, use a CardStack component for animated transitions and swipe to go back.
     const AppLayout = Platform.OS === 'web' ? tabs.Layout : BackgroundView;
-    const NavigatorStack = Platform.OS === 'web' ? Switch : CardStack;
 
     return (
       <BackgroundView>
@@ -215,7 +214,7 @@ class AppRouter extends PureComponent {
         ) : (
           <Player>
             <AppLayout>
-              <NavigatorStack
+              <CardStack
                 location={
                   this.isModal || this.musicPlayerIsOpened ? previousLocation : this.props.location
                 }
@@ -309,7 +308,7 @@ class AppRouter extends PureComponent {
                 <Route exact path="/_/reset-password/:token" component={ResetPassword} />
 
                 <Route cardStackKey="tabs" component={this.tabs} />
-              </NavigatorStack>
+              </CardStack>
             </AppLayout>
             <Switch>{this.isModal ? this.largeScreenModals : null}</Switch>
           </Player>

--- a/src/give/Dashboard.js
+++ b/src/give/Dashboard.js
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import { ScrollView, TouchableWithoutFeedback } from 'react-native';
 import PropTypes from 'prop-types';
-import { compose, branch, renderComponent, withProps } from 'recompose';
+import { compose, withPropsOnChange, onlyUpdateForKeys } from 'recompose';
 import get from 'lodash/get';
 import ActivityIndicator from '@ui/ActivityIndicator';
 import { withRouter } from '@ui/NativeWebRouter';
@@ -37,6 +37,7 @@ export class Dashboard extends PureComponent {
     onPressNewScheduleLink: PropTypes.func,
     onPressTransactionCard: PropTypes.func,
     onPressScheduleCard: PropTypes.func,
+    isLoading: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -48,9 +49,11 @@ export class Dashboard extends PureComponent {
     onPressNewScheduleLink() {},
     onPressTransactionCard() {},
     onPressScheduleCard() {},
+    isLoading: false,
   };
 
   render() {
+    if (this.props.isLoading) return <ActivityIndicator />;
     return (
       <BackgroundView>
         <ScrollView>
@@ -139,7 +142,8 @@ export class Dashboard extends PureComponent {
 const enhance = compose(
   withGivingDashboard,
   withRouter,
-  withProps(props => ({
+  onlyUpdateForKeys(['isLoading', 'scheduledTransactions', 'activityItems', 'savedPaymentMethods']),
+  withPropsOnChange(['route', 'history'], props => ({
     onPressActivityLink() {
       props.route.jumpTo('ContributionHistory');
     },
@@ -156,7 +160,6 @@ const enhance = compose(
       props.history.push(`/give/schedules/${id}`);
     },
   })),
-  branch(({ isLoading }) => isLoading, renderComponent(ActivityIndicator)),
 );
 
 export default enhance(Dashboard);

--- a/src/give/RestoredCheckout.js
+++ b/src/give/RestoredCheckout.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React from 'react';
 import { View } from 'react-native';
 import get from 'lodash/get';
@@ -6,6 +7,8 @@ import {
   branch,
   withState,
   renderComponent,
+  mapProps,
+  pure,
 } from 'recompose';
 import { H4, H7 } from '@ui/typography';
 import ActivityIndicator from '@ui/ActivityIndicator';
@@ -22,10 +25,15 @@ const PaperView = styled(({ theme }) => ({
 }), 'PaperView')(View);
 
 const enhance = compose(
+  mapProps(() => ({})),
+  pure,
   withoutTabBar,
   withRestoredGive,
   withState('paymentCompletion', 'setPaymentCompletion', false),
-  branch(({ isRestored }) => !isRestored, renderComponent(ActivityIndicator)),
+  branch(
+    ({ isRestored, contributions }) => !isRestored || !contributions,
+    renderComponent(ActivityIndicator),
+  ),
 );
 
 export const RestoredCheckout = enhance((props) => {

--- a/src/give/ScheduleDetails/ScheduleTransactionHistory.js
+++ b/src/give/ScheduleDetails/ScheduleTransactionHistory.js
@@ -50,7 +50,19 @@ const ScheduleTransactionHistory = ({ transactions = [], isLoading = false }) =>
 );
 
 ScheduleTransactionHistory.propTypes = {
-  transactions: PropTypes.arrayOf(),
+  transactions: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.any, // eslint-disable-line
+    details: PropTypes.arrayOf(PropTypes.shape({
+      amount: PropTypes.number,
+      account: PropTypes.shape({ name: PropTypes.string }),
+    })),
+    person: PropTypes.shape({
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+      photo: PropTypes.string,
+    }),
+    date: PropTypes.string,
+  })),
   isLoading: PropTypes.bool,
 };
 


### PR DESCRIPTION
~Fixes #604~

Implements a few mild performance optimizations:

- Limits dashboard re-rendering a7d6c86
- Fix issue where StyleSheet.create() is called when it doesn't need to be
- Limit RestoredCheckout re-rendering

With #616, I am not sure that this PR is still needed or worth merging. It originally removed the `CardStack` on web, which resulted in a lighter memory footprint and conveniently "fixed" the issue presented in #604. However, it appears that #616 is a better fix...so I reversed the commit I made disabling `CardStack` on web, but I'm still left with the above three potentially "micro" optimizations.

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

