### PR TITLE
650 Remove space before exclamation point

### DIFF
--- a/src/group-finder/NoResults.js
+++ b/src/group-finder/NoResults.js
@@ -13,9 +13,15 @@ const AdUnit = () => (
     <CardContent>
       <PaddedView>
         <StyledBodyText italic>
-          {'Unfortunately, we didn\'t find any groups matching your search. Gather some friends, and '}
-          <ButtonLink onPress={() => WebBrowser.openBrowserAsync('https://rock.newspring.cc/workflows/81')}>start your own group</ButtonLink>
-          {' !'}
+          {
+            "Unfortunately, we didn't find any groups matching your search. Gather some friends, and "
+          }
+          <ButtonLink
+            onPress={() => WebBrowser.openBrowserAsync('https://rock.newspring.cc/workflows/81')}
+          >
+            start your own group
+          </ButtonLink>
+          {'!'}
         </StyledBodyText>
       </PaddedView>
     </CardContent>


### PR DESCRIPTION
Fixes #650 by removing the space before the exclamation point that shows up when there are no groups in the group finder search result.

## Creator

- [x] Build relevant tests if any apply
- [x] Ensure there are no new warnings
- [x] Upload an animated GIF showcasing the solution (if it applies)
- [x] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

![simulator screen shot - iphone x - 2018-05-18 at 14 32 59](https://user-images.githubusercontent.com/2053547/40252096-3b10ee00-5aa9-11e8-9e27-c3be65f8483c.png)


