### PR TITLE
636 Add fontStyle for Safari to display italics

### DIFF
--- a/src/@ui/typography/BodyText/index.js
+++ b/src/@ui/typography/BodyText/index.js
@@ -6,12 +6,16 @@ import { withPlaceholder, Typography } from '@ui/Placeholder';
 
 const styles = styled(({ theme, bold, italic }) => {
   let fontStack = theme.typography.fontFamilySerif.regular.default;
+  let fontStyle = null;
+
   if (bold && italic) {
     fontStack = theme.typography.fontFamilySerif.bold.italic;
+    fontStyle = 'italic';
   } else if (bold) {
     fontStack = theme.typography.fontFamilySerif.bold.default;
   } else if (italic) {
     fontStack = theme.typography.fontFamilySerif.regular.italic;
+    fontStyle = 'italic';
   }
 
   return {
@@ -31,6 +35,7 @@ const styles = styled(({ theme, bold, italic }) => {
         paddingTop: theme.helpers.rem(0.125),
         paddingBottom: theme.helpers.rem(0.1),
         lineHeight: theme.helpers.verticalRhythm(1.112, 1.4889),
+        fontStyle: fontStyle, // eslint-disable-line
         '-webkit-font-smoothing': 'antialiased',
         '-moz-osx-font-smoothing': 'grayscale',
       },

--- a/src/assets/fonts/DroidSerif.css
+++ b/src/assets/fonts/DroidSerif.css
@@ -1,36 +1,52 @@
-@font-face{
-    font-family: 'DroidSerif-Regular';
-    font-style: normal;
-    font-weight: 400;
-    src: url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Regular.eot"); /* IE9 Compat Modes */
-    src: url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Regular.woff2") format("woff2"), /* Super Modern Browsers */
-         url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Regular.woff") format("woff"), /* Pretty Modern Browsers */
-         url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Regular.ttf") format("truetype"); /* Safari, Android, iOS */
+@font-face {
+  font-family: 'DroidSerif-Regular';
+  font-style: normal;
+  font-weight: 400;
+  src: url('https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Regular.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Regular.woff')
+      format('woff'),
+    /* Pretty Modern Browsers */
+      url('https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Regular.ttf')
+      format('truetype'); /* Safari, Android, iOS */
 }
-@font-face{
-    font-family: 'DroidSerif-RegularItalic';
-    font-style:  italic;
-    font-weight: 400;
-    src: url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Italic.eot"); /* IE9 Compat Modes */
-    src: url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Italic.woff2") format("woff2"), /* Super Modern Browsers */
-         url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Italic.woff") format("woff"), /* Pretty Modern Browsers */
-         url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Italic.ttf") format("truetype"); /* Safari, Android, iOS */
+@font-face {
+  font-family: 'DroidSerif-RegularItalic';
+  font-style: italic;
+  font-weight: 400;
+  src: url('https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Italic.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Italic.woff')
+      format('woff'),
+    /* Pretty Modern Browsers */
+      url('https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Italic.ttf')
+      format('truetype'); /* Safari, Android, iOS */
 }
-@font-face{
-    font-family: 'DroidSerif-Bold';
-    font-style: normal;
-    font-weight: 700;
-    src: url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Bold.eot"); /* IE9 Compat Modes */
-    src: url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Bold.woff2") format("woff2"), /* Super Modern Browsers */
-         url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Bold.woff") format("woff"), /* Pretty Modern Browsers */
-         url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Bold.ttf") format("truetype"); /* Safari, Android, iOS */
+@font-face {
+  font-family: 'DroidSerif-Bold';
+  font-style: normal;
+  font-weight: 700;
+  src: url('https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Bold.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Bold.woff')
+      format('woff'),
+    /* Pretty Modern Browsers */
+      url('https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-Bold.ttf')
+      format('truetype'); /* Safari, Android, iOS */
 }
-@font-face{
-    font-family: 'DroidSerif-BoldItalic';
-    font-style:  italic;
-    font-weight: 700;
-    src: url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-BoldItalic.eot"); /* IE9 Compat Modes */
-    src: url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-BoldItalic.woff2") format("woff2"), /* Super Modern Browsers */
-         url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-BoldItalic.woff") format("woff"), /* Pretty Modern Browsers */
-         url("https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-BoldItalic.ttf") format("truetype"); /* Safari, Android, iOS */
+@font-face {
+  font-family: 'DroidSerif-BoldItalic';
+  font-style: italic;
+  font-weight: 700;
+  src: url('https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-BoldItalic.woff2')
+      format('woff2'),
+    /* Super Modern Browsers */
+      url('https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-BoldItalic.woff')
+      format('woff'),
+    /* Pretty Modern Browsers */
+      url('https://d3n6tjerleuu41.cloudfront.net/fonts/droid-serif/DroidSerif-BoldItalic.ttf')
+      format('truetype'); /* Safari, Android, iOS */
 }


### PR DESCRIPTION
Fixes #636 

## Creator

- [x] Build relevant tests if any apply
- [x] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [x] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

