### PR TITLE
fix-schedule-giving-dates

### DIFF
--- a/src/@data/withGive/selectors/getOrderDetails.js
+++ b/src/@data/withGive/selectors/getOrderDetails.js
@@ -48,8 +48,8 @@ export default function getOrderDetails(state) {
         break;
     }
 
-    joinedData['start-date'] = state.start
-      ? moment(state.start).format('YYYYMMDD')
+    joinedData['start-date'] = state.startDate
+      ? moment(state.startDate).format('YYYYMMDD')
       : moment()
         .add(1, 'days')
         .format('YYYYMMDD');


### PR DESCRIPTION
Fixed an issue where users scheduled contributions would trigger 24 hours after initial creation instead of set date.

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

