### PR TITLE
Fix Signup Route

### DIFF
--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -85,9 +85,6 @@ class AppRouter extends PureComponent {
   }
 
   get isModal() {
-    if (this.props.location.pathname === '/signup') {
-      return false;
-    }
     return (
       this.props.isLargeScreen &&
       previousLocation &&

--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -197,8 +197,6 @@ class AppRouter extends PureComponent {
     </View>
   );
 
-  // const redirectToMyDot = path => window.location.replace(`https://my.newspring.cc/${path}`);
-
   render() {
     // On Web we render the tab layout at this level as tabs are visible in all app routes
     // On mobile, use a CardStack component for animated transitions and swipe to go back.

--- a/src/AppRouter.js
+++ b/src/AppRouter.js
@@ -40,7 +40,6 @@ import Settings, { ProfileDetails, ProfileAddress, ChangePassword } from './sett
 import { Results as GroupFinderResults, GroupSingle } from './group-finder';
 
 const redirectToNewspring = path => window.location.replace(`https://newspring.cc/${path}`);
-const redirectToMyDot = path => window.location.replace(`https://my.newspring.cc/${path}`);
 
 let previousLocation;
 
@@ -86,10 +85,14 @@ class AppRouter extends PureComponent {
   }
 
   get isModal() {
+    if (this.props.location.pathname === '/signup') {
+      return false;
+    }
     return (
       this.props.isLargeScreen &&
       previousLocation &&
       previousLocation.pathname !== this.props.location.pathname &&
+      previousLocation.pathname !== '/signup' &&
       this.largeScreenModals.find(route =>
         matchPath(this.props.location.pathname, route.props.path),
       )
@@ -194,9 +197,10 @@ class AppRouter extends PureComponent {
       <Route path="/live" component={() => redirectToNewspring('live')} />
       <Route path="/watchandread" component={() => redirectToNewspring('watchandread')} />
       <Route path="/nextsteps" component={() => redirectToNewspring('nextsteps')} />
-      <Route path="/signup" component={() => redirectToMyDot('login')} />
     </View>
   );
+
+  // const redirectToMyDot = path => window.location.replace(`https://my.newspring.cc/${path}`);
 
   render() {
     // On Web we render the tab layout at this level as tabs are visible in all app routes
@@ -221,6 +225,7 @@ class AppRouter extends PureComponent {
                   this.isModal || this.musicPlayerIsOpened ? previousLocation : this.props.location
                 }
               >
+                <Redirect from="/signup" to="/profile" />
                 <Redirect from="/sermons" to="/series" />
                 <Route exact path="/series" component={Series} />
                 <Route exact path="/series/:id" component={SeriesSingle} />


### PR DESCRIPTION
Changed `/signup` route and hardcoded so that the login route does not render as a modal in this case

Fixes [issue-number]

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

