### PR TITLE
Remove Fuse Church Online

### DIFF
--- a/src/@data/withLiveNow/index.js
+++ b/src/@data/withLiveNow/index.js
@@ -5,7 +5,6 @@ export const QUERY = gql`
   query Live {
     live {
       live
-      fuse
     }
   }
 `;
@@ -14,7 +13,6 @@ export default graphql(QUERY, {
   props: ({ data: { error, live = {} } = {} }) => ({
     error,
     isLive: live.live,
-    isFuse: live.fuse,
     embedUrl: live.embedUrl,
   }),
   options: () => ({

--- a/src/@ui/LiveNowButton/index.js
+++ b/src/@ui/LiveNowButton/index.js
@@ -26,9 +26,8 @@ const LiveNowButton = enhance(
   ({
     error,
     isLive,
-    isFuse,
     titleText = 'NewSpring Church Live. Watch Now!',
-    liveNowPath = isFuse ? 'https://live.newspringfuse.com' : 'https://live.newspring.cc',
+    liveNowPath = 'https://live.newspring.cc',
   }) => {
     if (error || !isLive || Platform.OS === 'web') return null;
     return (


### PR DESCRIPTION
- This should remove the link out to `https://live.newspringfuse.com` and anything specifically related to looking up whether an event is specifically for Fuse.