### PR TITLE
Fix Group Finder Contact Link

### DIFF
--- a/src/group-finder/GroupSingle.js
+++ b/src/group-finder/GroupSingle.js
@@ -71,7 +71,7 @@ const leadersLoadingState = [
 ];
 
 const handleGroupContact = ({ guid, loginParam }) => {
-  WebBrowser.openBrowserAsync(`${rockUrl}Workflows/304?Group=${guid}${loginParam}`);
+  WebBrowser.openBrowserAsync(`${rockUrl}Workflows/304?Group=${guid}&${loginParam}`);
   track(events.ContactedGroup, { guid });
 };
 


### PR DESCRIPTION
- Added `&` to the contact link for correct query string formatting.