### PR TITLE
Fixed Misspelling in Saved Payment Form

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,18 @@
 Fixes [issue-number]
 
-## Creator
+Creator
+-------
 
 - [ ] Build relevant tests if any apply
 - [ ] Ensure there are no new warnings
 - [ ] Upload an animated GIF showcasing the solution (if it applies)
 - [ ] Set a relevant reviewer
 
-## Reviewer
+Reviewer
+--------
 
 - [ ] Run `test` and make sure all tests pass
 - [ ] Review function and form on iOS
 - [ ] Review function and form on Android
 - [ ] Review function and form on Web
 - [ ] Review new test logic
-

--- a/src/@ui/forms/SavedPaymentReviewForm.js
+++ b/src/@ui/forms/SavedPaymentReviewForm.js
@@ -33,7 +33,6 @@ const SmallValueText = compose(
   })),
 )(H6);
 
-
 export class PaymentConfirmationFormWithoutData extends PureComponent {
   static propTypes = {
     isLoading: PropTypes.bool,
@@ -112,7 +111,7 @@ export class PaymentConfirmationFormWithoutData extends PureComponent {
           <SmallValueText>{this.props.cvv}</SmallValueText>
         </Row>
         <Row>
-          <LabelText>Accout Name: </LabelText>
+          <LabelText>Account Name: </LabelText>
           <SmallValueText>{this.props.savedAccountName}</SmallValueText>
         </Row>
       </PaddedView>
@@ -147,11 +146,17 @@ export class PaymentConfirmationFormWithoutData extends PureComponent {
             <H5>{'Account Details'}</H5>
           </Cell>
           <Divider />
-          {this.props.paymentMethod === 'bankAccount' ? this.renderBankAccount() : this.renderCreditCard()}
+          {this.props.paymentMethod === 'bankAccount'
+            ? this.renderBankAccount()
+            : this.renderCreditCard()}
         </TableView>
 
         <PaddedView>
-          <Button onPress={this.props.onSubmit} title="Create Account" loading={this.props.isSaving} />
+          <Button
+            onPress={this.props.onSubmit}
+            title="Create Account"
+            loading={this.props.isSaving}
+          />
         </PaddedView>
       </View>
     );


### PR DESCRIPTION
Fixes [SYS-4478 App does not grab expiration date for credit card payment accounts to send to Rock](https://newspring.atlassian.net/browse/SYS-4478)

This part of a bigger bug, fixed on [NewSpring/Rock](https://github.com/NewSpring/Rock/pull/754)

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic