### PR TITLE
(SYS-4589) Script to Increment Version Number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# python files
+*.pyc
+
 # create react native app
 .expo/
 .env

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "create-app-entrypoint": "node ./.scripts/create-app-entrypoint.js",
     "create-storybook-entrypoint": "node ./.scripts/create-storybook-entrypoint.js",
     "run-with-settings": "node ./.scripts/run-with-settings.js",
-    "create-env-files": "node ./.scripts/generate-env-files.js"
+    "create-env-files": "node ./.scripts/generate-env-files.js",
+    "bump": "python ./scripts/bump_version.py"
   },
   "jest": {
     "preset": "jest-expo",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollos",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "repository": "https://github.com/NewSpring/Apollos.git",
   "author": "differential",
   "license": "MIT",

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -6,8 +6,8 @@ def _getArgs():
     """Get arguments from command line."""
 
     parser = argparse.ArgumentParser(
-        description="This will bump the version numbers for NS Apollos")
-    parser.add_argument("version", help="version string to be copied in")
+        description="This will bump the version numbers for NS Apollos files.")
+    parser.add_argument("version", help="Version string to be copied in")
     args = parser.parse_args()
     return args
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     
     # write over JS files
     _replaceLine("./app-config.js", "version:", "    version: '" + version + "',") 
-    _replaceLine("./package.json", "version:", "  \"version\": \"" + version + "\",") 
+    _replaceLine("./package.json", "version\":", "  \"version\": \"" + version + "\",") 
     
     # write over Android files
     _replaceLine("./android/app/build.gradle", "versionName", "    versionName '" + version + "'")

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -8,7 +8,7 @@ def _getArgs():
 
     parser = argparse.ArgumentParser(
         description="This will bump the version numbers for NS Apollos files.")
-    parser.add_argument("version", help="Version string to be copied in")
+    parser.add_argument("version", help="Version number to update to")
     parser.add_argument("--ota", action="store_true", help="This will publish the bundle to Expo")
     args = parser.parse_args()
     return args

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,55 @@
+#! usr/bin/python
+
+import argparse
+
+def _getArgs():
+    """Get arguments from command line."""
+
+    parser = argparse.ArgumentParser(
+        description="This will bump the version numbers for NS Apollos")
+    parser.add_argument("version", help="version string to be copied in")
+    args = parser.parse_args()
+    return args
+
+def _replaceLine(textFile, lineSearch, newLine, lineOffset = 0):
+    """This will replace a line in a file with a new line."""
+    try:
+        with open (textFile, "r") as f:
+            data = []
+            found = False
+            replaceThisLine = lineOffset
+            for i, line in enumerate(f.readlines()):
+                if (lineSearch in line) or found: 
+                    found = True
+                    if replaceThisLine == 0: 
+                        data.append(newLine + "\n")
+                        found = False
+                    else:
+                        replaceThisLine -= 1
+                        data.append(line)
+                else:
+                    data.append(line)
+    except IOError:
+        print "File does not exist"
+        return 
+
+    with open (textFile, "w") as f:
+        f.writelines(data)
+                
+if __name__ == "__main__":
+
+    # get arguments
+    args = _getArgs()
+    version = args.version
+    
+    # write over JS files
+    _replaceLine("./app-config.js", "version:", "    version: '" + version + "',") 
+    
+    # write over Android files
+    _replaceLine("./android/app/build.gradle", "versionName", "    versionName '" + version + "'")
+    _replaceLine("./android/app/src/main/java/host/exp/exponent/generated/AppConstants.java", "String RELEASE", "  public static final String RELEASE_CHANNEL = \"v" + version + "\";")
+ 
+    # write over iOS files
+    _replaceLine("./ios/newspring/Supporting/Info.plist", "CFBundleShortVersionString", "	<string>" + version + "</string>", 1) 
+    _replaceLine("./ios/newspring/Supporting/EXShell.plist", "releaseChannel", "	<string>v" + version + "</string>", 1) 
+ 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,6 +1,7 @@
 #! usr/bin/python
 
 import argparse
+import os
 
 def _getArgs():
     """Get arguments from command line."""

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -46,6 +46,7 @@ if __name__ == "__main__":
     
     # write over JS files
     _replaceLine("./app-config.js", "version:", "    version: '" + version + "',") 
+    _replaceLine("./package.json", "version:", "  \"version\": \"" + version + "\",") 
     
     # write over Android files
     _replaceLine("./android/app/build.gradle", "versionName", "    versionName '" + version + "'")
@@ -58,5 +59,4 @@ if __name__ == "__main__":
     # publish to Expo
     if args.ota:
         os.system("NODE_ENV=production yarn run-with-settings \"yarn run exp publish --release-channel v" + args.version + "\"")
-        print "NODE_ENV=production yarn run-with-settings \"yarn run exp publish --release-channel v" + args.version + "\"" 
  

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -6,18 +6,13 @@ import sys
 import json
 import logging
 
-def _getArgs(noArgs = False):
+def _getArgs():
     """Get arguments from command line."""
 
     parser = argparse.ArgumentParser(
         description="This will bump the version numbers for NS Apollos files.")
     parser.add_argument("-v", "--version", help="Version number to update to")
     parser.add_argument("--ota", action="store_true", help="This will publish the bundle to Expo")
-
-    if noArgs:
-        parser.print_help()
-        return 0
-
     args = parser.parse_args()
     return args
 
@@ -58,9 +53,10 @@ def _replaceLine(textFile, lineSearch, newLine, lineOffset = 0):
                 
 if __name__ == "__main__":
 
-    # if no args, print help menu and exit
+    # all arguments are optional since --ota can be called without version number
+    # if no args, warn user and exit 
     if len(sys.argv) == 1:
-        _getArgs(True)
+        logging.warn("No arguments specified. Use -h flag for usage info.")
         sys.exit(1)
     
     # get command line arguments

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -56,5 +56,6 @@ if __name__ == "__main__":
 
     # publish to Expo
     if args.ota:
-        os.system("NODE_ENV=production yarn run-with-settings \"yarn run exp publish --release-channel v" + args.version + "beta\"")
+        os.system("NODE_ENV=production yarn run-with-settings \"yarn run exp publish --release-channel v" + args.version + "\"")
+        print "NODE_ENV=production yarn run-with-settings \"yarn run exp publish --release-channel v" + args.version + "\"" 
  

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -8,6 +8,7 @@ def _getArgs():
     parser = argparse.ArgumentParser(
         description="This will bump the version numbers for NS Apollos files.")
     parser.add_argument("version", help="Version string to be copied in")
+    parser.add_argument("--ota", action="store_true", help="This will publish the bundle to Expo")
     args = parser.parse_args()
     return args
 
@@ -52,4 +53,8 @@ if __name__ == "__main__":
     # write over iOS files
     _replaceLine("./ios/newspring/Supporting/Info.plist", "CFBundleShortVersionString", "	<string>" + version + "</string>", 1) 
     _replaceLine("./ios/newspring/Supporting/EXShell.plist", "releaseChannel", "	<string>v" + version + "</string>", 1) 
+
+    # publish to Expo
+    if args.ota:
+        os.system("NODE_ENV=production yarn run-with-settings \"yarn run exp publish --release-channel v" + args.version + "beta\"")
  

--- a/src/@ui/forms/PaymentConfirmationForm.js
+++ b/src/@ui/forms/PaymentConfirmationForm.js
@@ -124,20 +124,27 @@ export class PaymentConfirmationFormWithoutData extends PureComponent {
             <Divider key={`${contribution.name}-divider`} />,
           ])}
 
-          {this.props.contributions.frequencyId && this.props.contributions.frequencyId !== 'today'
+          {this.props.contributions.frequencyId &&
+          this.props.contributions.frequencyId !== 'today'
             ? [
               <PaddedView horizontal={false} key="view">
                 <LargeCellText>Schedule Details</LargeCellText>
                 <Row>
                   <LabelText>Frequency: </LabelText>
                   <SmallValueText>
-                    {FREQUENCY_IDS.find(f => f.id === this.props.contributions.frequencyId).label}
+                    {
+                        FREQUENCY_IDS.find(
+                          f => f.id === this.props.contributions.frequencyId,
+                        ).label
+                      }
                   </SmallValueText>
                 </Row>
                 <Row>
                   <LabelText>Starting: </LabelText>
                   <SmallValueText>
-                    {moment(this.props.contributions.startDate).format('MM/DD/YYYY')}
+                    {moment(this.props.contributions.startDate).format(
+                        'MM/DD/YYYY',
+                      )}
                   </SmallValueText>
                 </Row>
               </PaddedView>,
@@ -162,7 +169,10 @@ export class PaymentConfirmationFormWithoutData extends PureComponent {
         ) : null}
 
         <PaddedView vertical={false}>
-          <Button onPress={this.props.onSubmit} loading={this.props.contributions.isPaying}>
+          <Button
+            onPress={this.props.onSubmit}
+            loading={this.props.contributions.isPaying}
+          >
             <H5>{this.props.submitButtonText} </H5>
             {this.props.submitButtonIcon ? (
               <Icon name={this.props.submitButtonIcon} size={24} />
@@ -192,7 +202,8 @@ const PaymentConfirmationForm = compose(
   withCheckout,
   withProps((props) => {
     const campus =
-      props.campuses && props.campuses.find(c => c.id === get(props, 'contributions.campusId'));
+      props.campuses &&
+      props.campuses.find(c => c.id === get(props, 'contributions.campusId'));
 
     return {
       campus: campus && campus.label,
@@ -214,13 +225,12 @@ const PaymentConfirmationForm = compose(
           const userToken = await AsyncStorage.getItem('authToken');
 
           const res = await Linking.openURL(
-            `${Settings.APP_ROOT_URL || 'http://localhost:3000'}/give/restored-checkout?${stringify(
-              {
-                redirect: `${linkingUri}${props.navigateToOnComplete}`,
-                state: JSON.stringify(props.contributions),
-                userToken,
-              },
-            )}`,
+            `${Settings.APP_ROOT_URL ||
+              'http://localhost:3000'}/give/restored-checkout?${stringify({
+              redirect: `${linkingUri}${props.navigateToOnComplete}`,
+              state: JSON.stringify(props.contributions),
+              userToken,
+            })}`,
           );
 
           return res;
@@ -231,10 +241,20 @@ const PaymentConfirmationForm = compose(
           await props.validateSingleCardTransaction(); // This seems unnecessary
         }
 
-        const isSavedPaymentMethod = props.contributions.paymentMethod === 'savedPaymentMethod';
+        const isSavedPaymentMethod =
+          props.contributions.paymentMethod === 'savedPaymentMethod';
         const isScheduled = props.contributions.frequencyId !== 'today';
         if (isSavedPaymentMethod && isScheduled) {
-          await props.createOrder();
+          const createOrderResponse = await props.createOrder();
+          const unableToCreateOrderError = get(
+            createOrderResponse,
+            'data.order.error',
+          );
+          if (unableToCreateOrderError) {
+            throw new Error(
+              'Unable to process schedule with this account. Please use a different payment method.',
+            );
+          }
 
           props.setPaymentResult({
             success: true,
@@ -255,8 +275,13 @@ const PaymentConfirmationForm = compose(
             : null,
           platform: props.fromIos ? 'ios' : Platform.OS,
         });
-        const unableToCompleteOrderError = get(completeOrderRes, 'data.response.error');
-        if (unableToCompleteOrderError) throw new Error(unableToCompleteOrderError);
+        const unableToCompleteOrderError = get(
+          completeOrderRes,
+          'data.response.error',
+        );
+        if (unableToCompleteOrderError) {
+          throw new Error(unableToCompleteOrderError);
+        }
 
         props.setPaymentResult({
           success: true,
@@ -294,13 +319,18 @@ const PaymentConfirmationForm = compose(
 
       const verb = isScheduled ? 'Schedule' : 'Give';
 
-      const name = (paymentMethod.accountNumber || paymentMethod.cardNumber || '')
+      const name = (
+        paymentMethod.accountNumber ||
+        paymentMethod.cardNumber ||
+        ''
+      )
         .replace(/-/g, '')
         .slice(-4);
 
       const text = `${verb} with ${name}`;
       const icon =
-        (paymentMethod.paymentMethod || contributions.paymentMethod) === 'creditCard'
+        (paymentMethod.paymentMethod || contributions.paymentMethod) ===
+        'creditCard'
           ? 'credit'
           : 'bank';
       return {


### PR DESCRIPTION
We can now use `yarn bump [VERSION_NUMBER]` to replace the string in all necessary files and even add the `--ota` flag to automatically publish to Expo.

![kapture 2018-12-17 at 9 10 27](https://user-images.githubusercontent.com/2659478/50092278-a806e300-01db-11e9-9ee6-7b3c80e95e7b.gif)


## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic