### PR TITLE
(SYS-4594) Initialize Payment String

### DIFF
--- a/src/@utils/last4.js
+++ b/src/@utils/last4.js
@@ -1,3 +1,6 @@
-export default function (str = '') {
-  return str.slice(str.length - 4, str.length);
+export default function (str) {
+  // needs to be initialized the old way for compatibility
+  let safeStr = str;
+  if (safeStr === null) safeStr = '';
+  return safeStr.slice(safeStr.length - 4, safeStr.length);
 }

--- a/src/@utils/last4.js
+++ b/src/@utils/last4.js
@@ -1,5 +1,5 @@
-export default function (str) {
-  // needs to be initialized the old way for compatibility
+export default function (str = '') {
+  // even though it's initialized, it can still be passed in as null
   let safeStr = str;
   if (safeStr === null) safeStr = '';
   return safeStr.slice(safeStr.length - 4, safeStr.length);

--- a/src/@utils/last4.js
+++ b/src/@utils/last4.js
@@ -1,6 +1,5 @@
 export default function (str = '') {
   // even though it's initialized, it can still be passed in as null
-  let safeStr = str;
-  if (safeStr === null) safeStr = '';
+  const safeStr = str || '';
   return safeStr.slice(safeStr.length - 4, safeStr.length);
 }


### PR DESCRIPTION
`null` was being passed into `last4()` from somewhere. This actually initializes it to an empty string.

https://sentry.io/newspring-church/apollos/issues/570550606/?query=is%3Aunresolved