### PR TITLE
(SYS-4590) Fixed Picker on ChromeOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "enzyme-to-json": "^3.3.1",
     "eslint": "^4.10.0",
     "eslint-config-airbnb": "^16.1.0",
+    "eslint-config-prettier": "^3.6.0",
     "eslint-import-resolver-babel-module": "^4.0.0-beta.3",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jest": "21.2.0",

--- a/src/@ui/ContributionsChartHero/index.js
+++ b/src/@ui/ContributionsChartHero/index.js
@@ -89,7 +89,7 @@ const ContributionsChartHero = enhance(
   }) => (
     <ScrollView
       contentContainerStyle={{
-      flexGrow: 1,
+        flexGrow: 1,
       }}
     >
       <Heroed
@@ -107,6 +107,7 @@ const ContributionsChartHero = enhance(
               key={currentYear - i}
               value={currentYear - i}
               label={currentYear - i}
+              color="black"
             />
           ))}
         </StyledPicker>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5142,6 +5142,13 @@ eslint-config-airbnb@^16.1.0:
   dependencies:
     eslint-config-airbnb-base "^12.1.0"
 
+eslint-config-prettier@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-3.6.0.tgz#8ca3ffac4bd6eeef623a0651f9d754900e3ec217"
+  integrity sha512-ixJ4U3uTLXwJts4rmSVW/lMXjlGwCijhBJHk8iVqKKSifeI0qgFEfWl8L63isfc8Od7EiBALF6BX3jKLluf/jQ==
+  dependencies:
+    get-stdin "^6.0.0"
+
 eslint-config-react-app@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-2.1.0.tgz#23c909f71cbaff76b945b831d2d814b8bde169eb"
@@ -6256,6 +6263,11 @@ get-stdin@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
   integrity sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This makes the picker items on the contribution hero always black. It was ugly in ChromeOS.

![screenshot 2019-01-23 at 11 57 26 am](https://user-images.githubusercontent.com/2659478/51623689-3ec76d80-1f07-11e9-8724-6201996951fa.png)

**MUST** test in ChromeOS.
