### PR TITLE
(SYS-4574) Updated Fund Input to ensure correct fund on review screen

### DIFF
--- a/src/@ui/forms/ContributionForm/__snapshots__/ContributionForm.tests.js.snap
+++ b/src/@ui/forms/ContributionForm/__snapshots__/ContributionForm.tests.js.snap
@@ -1758,6 +1758,11 @@ exports[`The ContributionForm component shows a second contribution 1`] = `
                     items={
                       Array [
                         Object {
+                          "label": "sterling",
+                          "textColor": undefined,
+                          "value": "one",
+                        },
+                        Object {
                           "label": "platinum",
                           "textColor": undefined,
                           "value": "two",
@@ -1767,7 +1772,7 @@ exports[`The ContributionForm component shows a second contribution 1`] = `
                     onChange={[Function]}
                     onResponderTerminationRequest={[Function]}
                     onStartShouldSetResponder={[Function]}
-                    selectedIndex={0}
+                    selectedIndex={1}
                     style={
                       Array [
                         Object {

--- a/src/@ui/forms/ContributionForm/index.js
+++ b/src/@ui/forms/ContributionForm/index.js
@@ -194,7 +194,7 @@ export class ContributionFormWithoutData extends Component {
             />
             {this.state.secondFundVisible && (
               <FundInput
-                funds={this.remainingFunds}
+                funds={this.props.funds}
                 value={this.props.values.secondContribution}
                 onChange={value => this.props.setFieldValue('secondContribution', value)}
                 onBlur={() => this.props.setFieldTouched('secondContribution', true)}


### PR DESCRIPTION
Fixes [SYS-4574](https://newspring.atlassian.net/secure/RapidBoard.jspa?rapidView=2&projectKey=SYS&modal=detail&selectedIssue=SYS-4574)

This change makes it possible to change a second fund and the fund persist to the review screen.
It still correctly selects a different fund than the original upon initial load.

## Creator

- [x] Build relevant tests if any apply
- [x] Ensure there are no new warnings
- [x] Upload an animated GIF showcasing the solution (if it applies)
- [x] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

