### PR TITLE
Fixes Android AppCenter Builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,8 @@ coverage/
 # generated at runtime
 ios/newspring/Supporting/EXBuildConstants.json
 ios/newspring/Supporting/EXBuildConstants.plist
-android/app/src/main/java/host/exp/exponent/generated/*
+ios/newspring/Supporting/EXBuildConstants.plist.bak
+android/app/src/main/java/host/exp/exponent/generated/DetachBuildConstants.java
 
 # Xcode
 #

--- a/android/app/src/main/java/host/exp/exponent/MainActivity.java
+++ b/android/app/src/main/java/host/exp/exponent/MainActivity.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-//import host.exp.exponent.generated.DetachBuildConstants;
+import host.exp.exponent.generated.DetachBuildConstants;
 import host.exp.exponent.experience.DetachActivity;
 
 public class MainActivity extends DetachActivity {
@@ -20,7 +20,7 @@ public class MainActivity extends DetachActivity {
 
   @Override
   public String developmentUrl() {
-    return "fakeStringForAppCenter";
+    return DetachBuildConstants.DEVELOPMENT_URL;
   }
 
   @Override

--- a/android/app/src/main/java/host/exp/exponent/MainActivity.java
+++ b/android/app/src/main/java/host/exp/exponent/MainActivity.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import host.exp.exponent.generated.DetachBuildConstants;
+//import host.exp.exponent.generated.DetachBuildConstants;
 import host.exp.exponent.experience.DetachActivity;
 
 public class MainActivity extends DetachActivity {
@@ -20,7 +20,7 @@ public class MainActivity extends DetachActivity {
 
   @Override
   public String developmentUrl() {
-    return DetachBuildConstants.DEVELOPMENT_URL;
+    return "fakeStringForAppCenter";
   }
 
   @Override

--- a/android/app/src/main/java/host/exp/exponent/generated/AppConstants.java
+++ b/android/app/src/main/java/host/exp/exponent/generated/AppConstants.java
@@ -1,0 +1,44 @@
+package host.exp.exponent.generated;
+
+import com.facebook.common.internal.DoNotStrip;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import host.exp.exponent.BuildConfig;
+import host.exp.exponent.Constants;
+
+@DoNotStrip
+public class AppConstants {
+
+  public static final String VERSION_NAME = "2.3.0";
+  public static String INITIAL_URL = "exp://exp.host/@newspring-builds/newspring";
+  public static final boolean IS_DETACHED = true;
+  public static final String SHELL_APP_SCHEME = "newspring";
+  public static final String RELEASE_CHANNEL = "v6.1.4";
+  public static boolean SHOW_LOADING_VIEW_IN_SHELL_APP = false;
+  public static final List<Constants.EmbeddedResponse> EMBEDDED_RESPONSES;
+
+  static {
+    List<Constants.EmbeddedResponse> embeddedResponses = new ArrayList<>();
+
+    // ADD EMBEDDED RESPONSES HERE
+    // START EMBEDDED RESPONSES
+    // END EMBEDDED RESPONSES
+    EMBEDDED_RESPONSES = embeddedResponses;
+  }
+
+  // Called from expoview/Constants
+  public static Constants.ExpoViewAppConstants get() {
+    Constants.ExpoViewAppConstants constants = new Constants.ExpoViewAppConstants();
+    constants.VERSION_NAME = VERSION_NAME;
+    constants.INITIAL_URL = INITIAL_URL;
+    constants.IS_DETACHED = IS_DETACHED;
+    constants.SHELL_APP_SCHEME = SHELL_APP_SCHEME;
+    constants.RELEASE_CHANNEL = RELEASE_CHANNEL;
+    constants.SHOW_LOADING_VIEW_IN_SHELL_APP = SHOW_LOADING_VIEW_IN_SHELL_APP;
+    constants.EMBEDDED_RESPONSES = EMBEDDED_RESPONSES;
+    constants.ANDROID_VERSION_CODE = BuildConfig.VERSION_CODE;
+    return constants;
+  }
+}

--- a/appcenter-post-clone.sh
+++ b/appcenter-post-clone.sh
@@ -15,3 +15,5 @@ mv ios/newspring/EXBuildConstants.plist.bak ios/newspring/Supporting/EXBuildCons
 
 # Android
 sed -i .bak 's/preBuild.dependsOn exponentPrebuildStep/\/\/preBuild.dependsOn exponentPrebuildStep/g' android/app/build.gradle
+sed -i .bak 's/import host.exp.exponent.generated.DetachBuildConstants;/\/\/import host.exp.exponent.generated.DetachBuildConstants;/g' android/app/src/main/java/host/exp/exponent/MainActivity.java
+sed -i .bak 's/return DetachBuildConstants.DEVELOPMENT_URL;/return "fakeStringForAppCenter";/g' android/app/src/main/java/host/exp/exponent/MainActivity.java


### PR DESCRIPTION
I removed one too many files in a previous PR which I think explains the app crashing, not the short links 🤦‍♂️. So I put that one back.

And then also, It was still looking for files that didn't exist in the build process, so I changed the `post_clone` script to comment out those lines in AppCenter.

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic