### PR TITLE
Adds PaddedView around group card image

### DIFF
--- a/src/group-finder/GroupCard.js
+++ b/src/group-finder/GroupCard.js
@@ -12,6 +12,7 @@ import Chip, { ChipList } from '@ui/Chip';
 import { Link } from '@ui/NativeWebRouter';
 import { ResponsiveSideBySideView } from '@ui/SideBySideView';
 import FlexedView from '@ui/FlexedView';
+import PaddedView from '@ui/PaddedView';
 import styled from '@ui/styled';
 
 const LeftColumn = compose(
@@ -78,9 +79,11 @@ const GroupCard = ({
   const card = (
     <Card isLoading={isLoading}>
       <ResponsiveSideBySideView reversed>
-        <ImageColumn>
-          <GroupCardImage source={{ url: photo }} />
-        </ImageColumn>
+        <PaddedView>
+          <ImageColumn>
+            <GroupCardImage source={{ url: photo }} />
+          </ImageColumn>
+        </PaddedView>
         <FlexedView>
           <LeftColumn>
             <H5>{name}</H5>


### PR DESCRIPTION
Fixes [4564](https://newspring.atlassian.net/secure/RapidBoard.jspa?rapidView=2&projectKey=SYS&modal=detail&selectedIssue=SYS-4564)

On Android, `overflow: hidden` doesn't work so we just have to warp the image with a component that has a defined height and width so that it doesn't fill the card.

## Creator

- [ ] Build relevant tests if any apply
- [ ] Ensure there are no new warnings
- [ ] Upload an animated GIF showcasing the solution (if it applies)
- [ ] Set a relevant reviewer

## Reviewer

- [ ] Run `test` and make sure all tests pass
- [ ] Review function and form on iOS
- [ ] Review function and form on Android
- [ ] Review function and form on Web
- [ ] Review new test logic

